### PR TITLE
Demote dashboard pages into panels chips

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -320,7 +320,7 @@ Detailed visual subsystem rules now live in `app/L0/_all/mod/_core/visual/AGENTS
 - `onscreen_menu/` owns the routed shell menu extension and feature-owned item seam; see `app/L0/_all/mod/_core/onscreen_menu/AGENTS.md`
 - `time_travel/` owns the routed Time Travel page for paginated writable-layer history, repository selection, file filters, diffs, previewed travel, and revert actions; see `app/L0/_all/mod/_core/time_travel/AGENTS.md`
 - `spaces/` owns the routed spaces canvas, first-login onboarding-space template bootstrap, empty-canvas prompt, widget SDK and widget-size ceilings, and persisted centered-coordinate space runtime plus dashboard-facing space metadata such as title, icon, color, and agent instructions; see `app/L0/_all/mod/_core/spaces/AGENTS.md`
-- `pages/` owns `ext/pages/*.yaml` manifest discovery and the dashboard-facing page launcher section; see `app/L0/_all/mod/_core/pages/AGENTS.md`
+- `pages/` owns `ext/pages/*.yaml` manifest discovery and the dashboard-facing secondary panels row; see `app/L0/_all/mod/_core/pages/AGENTS.md`
 
 ## Guidance
 

--- a/app/L0/_all/mod/_core/documentation/docs/app/modules-and-extensions.md
+++ b/app/L0/_all/mod/_core/documentation/docs/app/modules-and-extensions.md
@@ -120,7 +120,7 @@ Modules may also store lightweight metadata manifests under other `ext/` folders
 
 Current first-party example:
 
-- `_core/pages` discovers dashboard page manifests from `mod/<author>/<repo>/ext/pages/*.yaml` through `extensions_load`
+- `_core/pages` discovers dashboard page manifests from `mod/<author>/<repo>/ext/pages/*.yaml` through `extensions_load` and renders them as the dashboard's secondary `PANELS` chip row beneath the spaces launcher instead of as primary content cards
 - `_core/agent` publishes `ext/pages/agent.yaml` so the dashboard can launch the routed agent settings page without hardcoding it into dashboard or router; that route stays self-contained inside the module, keeps the astronaut info card, exposes only the external repo CTA, and edits the raw `~/conf/personality.system.include.md` prompt-include file
 - `_core/file_explorer` publishes `ext/pages/file_explorer.yaml` for the `#/file_explorer` Files route and also exposes `component.html` so the admin Files tab can reuse the same app-file browser without owning a second implementation
 - `_core/huggingface` publishes `ext/pages/huggingface.yaml` so the dashboard can launch the `Local LLM` page backed by the routed Hugging Face browser runtime

--- a/app/L0/_all/mod/_core/pages/AGENTS.md
+++ b/app/L0/_all/mod/_core/pages/AGENTS.md
@@ -4,7 +4,7 @@
 
 `_core/pages/` owns the page-manifest index used by the dashboard.
 
-It is a small headless-first module that discovers routed page manifests from module-owned `ext/pages/` YAML files through the shared extension resolver, normalizes that metadata into dashboard-friendly entries, and renders the dashboard's `Pages` section below the spaces launcher.
+It is a small headless-first module that discovers routed page manifests from module-owned `ext/pages/` YAML files through the shared extension resolver, normalizes that metadata into dashboard-friendly entries, and renders the dashboard's secondary `Panels` row beneath the spaces launcher.
 
 Documentation is top priority for this module. After any change under `_core/pages/`, update this file and any affected parent docs in the same session.
 
@@ -13,7 +13,7 @@ Documentation is top priority for this module. After any change under `_core/pag
 This module owns:
 
 - `page-index.js`: page-manifest discovery, YAML fetch or parse, route-path normalization, and page-card metadata shaping
-- `dashboard-launcher.html`, `dashboard-launcher.js`, and `dashboard-launcher.css`: the injected dashboard pages UI and route-open actions
+- `dashboard-launcher.html`, `dashboard-launcher.js`, and `dashboard-launcher.css`: the injected dashboard panels UI and route-open actions
 - `ext/html/_core/dashboard/content_end/pages-dashboard-launcher.html`: thin dashboard extension adapter
 
 ## Local Contracts
@@ -28,10 +28,11 @@ Current page-manifest contract:
 
 Current dashboard integration:
 
-- `_core/dashboard/` provides the `_core/dashboard/content_end` seam for the pages section
-- the pages launcher should stay below the spaces launcher and should not pull spaces-owned state into this module
-- dashboard page cards should stay compact with an explicit outer height cap; fit one title line plus two description lines, and clip any extra copy instead of allowing cards to grow taller
-- page cards should open routes through `space.router.goTo(...)` when the router runtime is available and fall back to updating `location.hash`
+- `_core/dashboard/` provides the `_core/dashboard/content_end` seam for the panels section
+- the panels launcher should stay below the spaces launcher and should not pull spaces-owned state into this module
+- the dashboard treatment is intentionally secondary navigation, not primary content: render a small uppercase `PANELS` eyebrow above one horizontal row of compact icon-plus-label pill chips
+- panel chips should keep a thin outlined border, transparent resting background, and visibly lower weight than the spaces cards above them; descriptions may still feed accessibility or hover affordances, but they should not render as second lines in the dashboard row
+- panel chips should open routes through `space.router.goTo(...)` when the router runtime is available and fall back to updating `location.hash`
 - the dashboard section should stay read-only; page manifests describe existing routed pages and do not create or mutate app files
 
 ## Development Guidance

--- a/app/L0/_all/mod/_core/pages/dashboard-launcher.css
+++ b/app/L0/_all/mod/_core/pages/dashboard-launcher.css
@@ -4,139 +4,135 @@
 
 .dashboard-pages-launcher-shell {
   display: grid;
-  gap: 1rem;
+  gap: 0.55rem;
+  justify-items: center;
 }
 
-.dashboard-pages-launcher-header h2 {
+.dashboard-pages-launcher-header {
+  width: 100%;
+  display: grid;
+  justify-items: center;
+}
+
+.dashboard-pages-launcher-eyebrow {
   margin: 0;
-  font-size: clamp(1.2rem, 1.9vw, 1.45rem);
-  letter-spacing: -0.03em;
+  font-size: 0.72rem;
+  line-height: 1;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
 }
 
 .dashboard-pages-launcher-empty {
   display: grid;
   place-items: center;
   gap: 0.4rem;
-  min-height: 7.5rem;
-  padding: 0.75rem 0;
+  min-height: 4.2rem;
+  padding: 0.15rem 0 0;
   text-align: center;
+}
+
+.dashboard-pages-launcher-empty x-icon {
+  color: var(--color-text-tertiary);
 }
 
 .dashboard-pages-launcher-empty p {
   margin: 0;
   max-width: 34ch;
-  color: var(--color-text-secondary);
+  font-size: 0.88rem;
+  color: var(--color-text-tertiary);
 }
 
-.dashboard-pages-launcher-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
-  gap: 0.85rem;
+.dashboard-pages-launcher-empty.is-error {
+  gap: 0.55rem;
 }
 
-.dashboard-page-card {
-  --dashboard-page-card-icon-color: var(--color-accent-primary);
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: start;
+.dashboard-pages-launcher-scroll {
+  width: 100%;
+  overflow-x: auto;
+  padding-bottom: 0.15rem;
+  scrollbar-width: thin;
+}
+
+.dashboard-pages-launcher-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   gap: 0.72rem;
-  box-sizing: border-box;
-  height: 5.05rem;
-  max-height: 5.05rem;
-  min-height: 5.05rem;
-  padding: 0.66rem 0.9rem;
-  border: 1px solid var(--space-chrome-border);
-  border-radius: 1.3rem;
-  background: rgba(13, 23, 39, 0.44);
-  box-shadow:
-    0 18px 42px rgba(1, 5, 14, 0.14),
-    inset 0 1px 0 rgba(255, 255, 255, 0.03);
-  color: inherit;
+  width: max-content;
+  min-width: 100%;
+  margin: 0 auto;
+}
+
+.dashboard-page-chip {
+  --dashboard-page-chip-icon-color: var(--color-text-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 2.55rem;
+  padding: 0.55rem 0.98rem;
+  border: 1px solid rgba(149, 176, 216, 0.18);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--color-text-secondary);
   text-decoration: none;
-  overflow: hidden;
+  white-space: nowrap;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
   transition:
     border-color 0.18s ease,
     background-color 0.18s ease,
+    color 0.18s ease,
     transform 0.18s ease,
     box-shadow 0.18s ease;
 }
 
-.dashboard-page-card:hover,
-.dashboard-page-card:focus-visible {
-  border-color: var(--space-chrome-border-strong);
-  background: rgba(13, 23, 39, 0.58);
+.dashboard-page-chip:hover,
+.dashboard-page-chip:focus-visible {
+  border-color: rgba(173, 201, 241, 0.3);
+  background: rgba(13, 23, 39, 0.18);
+  color: var(--color-text-primary);
   box-shadow:
-    0 22px 48px rgba(1, 5, 14, 0.22),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04);
-  transform: translateY(-2px);
+    inset 0 1px 0 rgba(255, 255, 255, 0.03),
+    0 10px 24px rgba(1, 5, 14, 0.12);
+  transform: translateY(-1px);
 }
 
-.dashboard-page-card:focus-visible {
+.dashboard-page-chip:focus-visible {
   outline: none;
 }
 
-.dashboard-page-card:active {
-  transform: translateY(1px) scale(0.995);
+.dashboard-page-chip:active {
+  transform: translateY(0) scale(0.992);
 }
 
-.dashboard-page-card-icon {
+.dashboard-page-chip-icon {
   display: inline-grid;
   place-items: center;
-  width: 2.25rem;
-  height: 2.25rem;
-  border-radius: 0.82rem;
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--dashboard-page-card-icon-color);
+  color: var(--dashboard-page-chip-icon-color);
 }
 
-.dashboard-page-card-icon x-icon {
-  font-size: 1.38rem;
+.dashboard-page-chip-icon x-icon {
+  font-size: 1.1rem;
 }
 
-.dashboard-page-card-copy {
-  display: grid;
-  align-content: start;
-  gap: 0.14rem;
-  min-width: 0;
-  overflow: hidden;
-}
-
-.dashboard-page-card-copy h3,
-.dashboard-page-card-copy p {
-  margin: 0;
-}
-
-.dashboard-page-card-copy h3 {
-  font-size: 0.95rem;
-  line-height: 1.04;
-  letter-spacing: -0.03em;
-  color: var(--color-text-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.dashboard-page-card-copy p {
-  font-size: 0.82rem;
-  line-height: 1.18;
-  color: var(--color-text-secondary);
-  overflow: hidden;
-  max-height: calc(2 * 1.18em);
-}
-
-@supports (-webkit-line-clamp: 2) {
-  .dashboard-page-card-copy p {
-    display: -webkit-box;
-    max-height: none;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
-  }
+.dashboard-page-chip-label {
+  font-size: 0.94rem;
+  line-height: 1;
+  letter-spacing: -0.01em;
 }
 
 @media (max-width: 640px) {
-  .dashboard-page-card {
-    height: 5.2rem;
-    max-height: 5.2rem;
-    min-height: 5.2rem;
+  .dashboard-pages-launcher-shell {
+    gap: 0.5rem;
+  }
+
+  .dashboard-pages-launcher-row {
+    gap: 0.55rem;
+  }
+
+  .dashboard-page-chip {
+    min-height: 2.45rem;
+    padding-inline: 0.86rem;
   }
 }

--- a/app/L0/_all/mod/_core/pages/dashboard-launcher.html
+++ b/app/L0/_all/mod/_core/pages/dashboard-launcher.html
@@ -4,16 +4,21 @@
     <script type="module" src="/mod/_core/pages/dashboard-launcher.js"></script>
   </head>
   <body>
-    <section class="dashboard-pages-launcher" x-data="pagesDashboardLauncher()" x-init="init()">
+    <section
+      class="dashboard-pages-launcher"
+      x-data="pagesDashboardLauncher()"
+      x-init="init()"
+      aria-labelledby="dashboard-panels-label"
+    >
       <div class="dashboard-pages-launcher-shell">
         <div class="dashboard-pages-launcher-header">
-          <h2>Pages</h2>
+          <p id="dashboard-panels-label" class="dashboard-pages-launcher-eyebrow">Panels</p>
         </div>
 
         <template x-if="loading">
           <div class="dashboard-pages-launcher-empty">
             <x-icon>schedule</x-icon>
-            <p>Loading pages…</p>
+            <p>Loading panels…</p>
           </div>
         </template>
 
@@ -30,32 +35,31 @@
 
         <template x-if="!loading && !loadErrorText && !hasEntries">
           <div class="dashboard-pages-launcher-empty">
-            <p>No pages are available for this account.</p>
+            <p>No panels are available for this account.</p>
           </div>
         </template>
 
         <template x-if="!loading && !loadErrorText && hasEntries">
-          <div class="dashboard-pages-launcher-grid">
-            <template x-for="item in entries" :key="item.id">
-              <a
-                class="dashboard-page-card"
-                :aria-label="`Open ${item.name}`"
-                :href="hrefFor(item.routePath)"
-                @click.prevent="openPage(item.routePath)"
-              >
-                <span
-                  class="dashboard-page-card-icon"
-                  :style="{ '--dashboard-page-card-icon-color': item.color }"
+          <div class="dashboard-pages-launcher-scroll">
+            <div class="dashboard-pages-launcher-row" role="list" aria-label="Dashboard panels">
+              <template x-for="item in entries" :key="item.id">
+                <a
+                  class="dashboard-page-chip"
+                  :aria-label="`Open ${item.name}`"
+                  :href="hrefFor(item.routePath)"
+                  :title="item.description || item.name"
+                  @click.prevent="openPage(item.routePath)"
                 >
-                  <x-icon x-text="item.icon"></x-icon>
-                </span>
-
-                <div class="dashboard-page-card-copy">
-                  <h3 x-text="item.name"></h3>
-                  <p x-text="item.description || `#/${item.routePath}`"></p>
-                </div>
-              </a>
-            </template>
+                  <span
+                    class="dashboard-page-chip-icon"
+                    :style="{ '--dashboard-page-chip-icon-color': item.color }"
+                  >
+                    <x-icon x-text="item.icon"></x-icon>
+                  </span>
+                  <span class="dashboard-page-chip-label" x-text="item.name"></span>
+                </a>
+              </template>
+            </div>
           </div>
         </template>
       </div>


### PR DESCRIPTION
Rework the dashboard pages launcher so Agent, Files, Local LLM, and Time Travel render as a subtle PANELS row beneath My Spaces instead of as competing content cards.

- replace the Pages heading and card grid with a small PANELS eyebrow and one horizontal row of pill-shaped icon chips
- reduce visual weight with transparent backgrounds, thin outlines, and compact icon + label presentation
- keep the row responsive as secondary navigation while preserving route launch behavior
- update the owning AGENTS/docs to reflect the new dashboard contract