### PR TITLE
prevent agent widget editing loops

### DIFF
--- a/app/L0/_all/mod/_core/spaces/ext/skills/space-widgets/SKILL.md
+++ b/app/L0/_all/mod/_core/spaces/ext/skills/space-widgets/SKILL.md
@@ -79,6 +79,13 @@ staged turns
 - After a successful patch or render, the next assistant turn should usually be the final user-facing answer. Do not output another promise line such as Updating... or Applying... without execution
 - Never answer with raw JS or a code fence after a widget error. Either send a proper execution message or a normal user-facing answer
 
+patch error loop prevention
+- After any patchWidget or renderWidget error, call readWidget on that widget before attempting another patch
+- Treat source as unseen unless readWidget succeeded in the current turn. Never infer line numbers from memory
+- If the same error repeats twice on the same widget, stop and call readWidget before retrying
+- If patchWidget fails with a syntax or reference error on a line you did not touch, the existing source is already broken — read first, then use renderWidget for a full rewrite
+- Never make more than 2 consecutive patches on the same widget without a readWidget in between
+
 examples
 Checking widget catalog
 _____javascript


### PR DESCRIPTION
Problem: agent (sonnet 4.7) entered endless loop making the same error trying to replace a couple of lines of code. It was convinced it knew what needed to be done but the edit always failed. Despited repeated attempts to get it back on track, only adding these rules to the local context finnaly stopped its hallucinations. 
Fix: Adds a "patch error loop prevention" subsection to app/L0/_all/mod/_core/spaces/ext/skills/space-widgets/SKILL.md, placed between staged turns and examples:

`patch error loop prevention
- After any patchWidget or renderWidget error, call readWidget on that widget before attempting another patch
- Treat source as unseen unless readWidget succeeded in the current turn. Never infer line numbers from memory
- If the same error repeats twice on the same widget, stop and call readWidget before retrying
- If patchWidget fails with a syntax or reference error on a line you did not touch, the existing source is already broken — read first, then use renderWidget for a full rewrite
- Never make more than 2 consecutive patches on the same widget without a readWidget in between`