### PR TITLE
Add Amazon Bedrock provider for the LLM settings (Converse + OpenAI)

### DIFF
--- a/app/L0/_all/mod/_core/admin/views/agent/config.js
+++ b/app/L0/_all/mod/_core/admin/views/agent/config.js
@@ -5,8 +5,69 @@ export const ADMIN_CHAT_HISTORY_PATH = "~/hist/admin-chat.json";
 export const DEFAULT_ADMIN_CHAT_MAX_TOKENS = 120_000;
 export const ADMIN_CHAT_LLM_PROVIDER = {
   API: "api",
+  BEDROCK: "bedrock",
   LOCAL: "local"
 };
+
+export const ADMIN_CHAT_BEDROCK_CRED_MODE = {
+  SERVER: "server",
+  CLIENT_KEY: "client-key"
+};
+
+export const ADMIN_CHAT_BEDROCK_ROUTE = {
+  CONVERSE: "converse",
+  OPENAI: "openai"
+};
+
+export const BEDROCK_MODEL_PRESETS = [
+  {
+    id: "us.anthropic.claude-sonnet-4-6",
+    label: "Claude Sonnet 4.6 (fast, recommended)",
+    route: "converse"
+  },
+  {
+    id: "us.anthropic.claude-opus-4-7",
+    label: "Claude Opus 4.7 (smartest)",
+    route: "converse"
+  },
+  {
+    id: "us.anthropic.claude-opus-4-6-v1",
+    label: "Claude Opus 4.6",
+    route: "converse"
+  },
+  {
+    id: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    label: "Claude Haiku 4.5 (cheap)",
+    route: "converse"
+  },
+  {
+    id: "openai.gpt-oss-20b-1:0",
+    label: "OpenAI gpt-oss 20B",
+    route: "openai"
+  },
+  {
+    id: "openai.gpt-oss-120b-1:0",
+    label: "OpenAI gpt-oss 120B",
+    route: "openai"
+  }
+];
+
+export function bedrockRouteForModel(modelId = "") {
+  const normalized = String(modelId || "").trim().toLowerCase();
+  if (!normalized) {
+    return ADMIN_CHAT_BEDROCK_ROUTE.CONVERSE;
+  }
+  if (normalized.startsWith("openai.")) {
+    return ADMIN_CHAT_BEDROCK_ROUTE.OPENAI;
+  }
+  return ADMIN_CHAT_BEDROCK_ROUTE.CONVERSE;
+}
+
+export function bedrockApiEndpointForRoute(route = ADMIN_CHAT_BEDROCK_ROUTE.CONVERSE) {
+  return route === ADMIN_CHAT_BEDROCK_ROUTE.OPENAI
+    ? "/api/bedrock/openai/v1/chat/completions"
+    : "/api/bedrock/converse/v1/chat/completions";
+}
 
 export const ADMIN_CHAT_LOCAL_PROVIDER = {
   HUGGINGFACE: "huggingface"
@@ -15,6 +76,9 @@ export const ADMIN_CHAT_LOCAL_PROVIDER = {
 export const DEFAULT_ADMIN_CHAT_SETTINGS = {
   apiEndpoint: "https://openrouter.ai/api/v1/chat/completions",
   apiKey: "",
+  bedrockApiKey: "",
+  bedrockCredMode: ADMIN_CHAT_BEDROCK_CRED_MODE.SERVER,
+  bedrockModel: BEDROCK_MODEL_PRESETS[0].id,
   huggingfaceDtype: "q4",
   huggingfaceModel: "",
   localProvider: ADMIN_CHAT_LOCAL_PROVIDER.HUGGINGFACE,
@@ -26,9 +90,19 @@ export const DEFAULT_ADMIN_CHAT_SETTINGS = {
 };
 
 export function normalizeAdminChatLlmProvider(value) {
-  return value === ADMIN_CHAT_LLM_PROVIDER.LOCAL
-    ? ADMIN_CHAT_LLM_PROVIDER.LOCAL
-    : ADMIN_CHAT_LLM_PROVIDER.API;
+  if (value === ADMIN_CHAT_LLM_PROVIDER.LOCAL) {
+    return ADMIN_CHAT_LLM_PROVIDER.LOCAL;
+  }
+  if (value === ADMIN_CHAT_LLM_PROVIDER.BEDROCK) {
+    return ADMIN_CHAT_LLM_PROVIDER.BEDROCK;
+  }
+  return ADMIN_CHAT_LLM_PROVIDER.API;
+}
+
+export function normalizeAdminChatBedrockCredMode(value) {
+  return value === ADMIN_CHAT_BEDROCK_CRED_MODE.CLIENT_KEY
+    ? ADMIN_CHAT_BEDROCK_CRED_MODE.CLIENT_KEY
+    : ADMIN_CHAT_BEDROCK_CRED_MODE.SERVER;
 }
 
 export function normalizeAdminChatLocalProvider(value) {

--- a/app/L0/_all/mod/_core/admin/views/agent/panel.html
+++ b/app/L0/_all/mod/_core/admin/views/agent/panel.html
@@ -179,43 +179,7 @@
                       <h2>Provider and model configuration</h2>
                     </div>
                   </header>
-                  <div class="dialog-segmented-control admin-agent-provider-switch" role="tablist" aria-label="LLM provider">
-                    <button
-                      type="button"
-                      class="secondary-button dialog-segmented-button"
-                      :class="{ 'is-active': $store.adminAgent.isSettingsDraftUsingApiProvider }"
-                      @click="$store.adminAgent.setSettingsProvider('api')"
-                    >
-                      <span>API</span>
-                    </button>
-                    <button
-                      type="button"
-                      class="secondary-button dialog-segmented-button"
-                      :class="{ 'is-active': $store.adminAgent.isSettingsDraftUsingLocalProvider }"
-                      @click="$store.adminAgent.setSettingsProvider('local')"
-                    >
-                      <span>Local</span>
-                    </button>
-                  </div>
-                  <div x-show="$store.adminAgent.isSettingsDraftUsingApiProvider" x-cloak>
-                    <label class="field">
-                      <span>Provider API Endpoint URL</span>
-                      <input type="url" x-model="$store.adminAgent.settingsDraft.apiEndpoint" />
-                    </label>
-                    <label class="field">
-                      <span>Model Name</span>
-                      <input type="text" x-model="$store.adminAgent.settingsDraft.model" />
-                    </label>
-                    <label class="field">
-                      <span>API Key</span>
-                      <input type="password" x-model="$store.adminAgent.settingsDraft.apiKey" />
-                    </label>
-                  </div>
-                  <div x-show="$store.adminAgent.isSettingsDraftUsingLocalProvider" x-cloak class="admin-agent-local-settings">
-                    <div class="admin-agent-local-provider-panel">
-                      <x-component path="/mod/_core/huggingface/config-sidebar.html" mode="admin"></x-component>
-                    </div>
-                  </div>
+                  <x-component path="/mod/_core/llm_settings/panel.html" mode="admin"></x-component>
                   <label class="field">
                     <span>Max Tokens</span>
                     <input type="number" min="1" step="1" inputmode="numeric" x-model="$store.adminAgent.settingsDraft.maxTokens" />

--- a/app/L0/_all/mod/_core/admin/views/agent/storage.js
+++ b/app/L0/_all/mod/_core/admin/views/agent/storage.js
@@ -199,7 +199,13 @@ export async function loadAdminChatConfig() {
   const runtime = getRuntime();
 
   try {
-    const result = await runtime.api.fileRead(config.ADMIN_CHAT_CONFIG_PATH);
+    const result = await runtime.api.fileRead({
+      path: config.ADMIN_CHAT_CONFIG_PATH,
+      allowMissing: true
+    });
+    if (result && result.exists === false) {
+      return createDefaultConfig();
+    }
     return normalizeStoredConfig(runtime, runtime.utils.yaml.parse(String(result?.content || "")));
   } catch (error) {
     if (isMissingFileError(error)) {
@@ -230,7 +236,13 @@ export async function loadAdminChatHistory() {
   const runtime = getRuntime();
 
   try {
-    const result = await runtime.api.fileRead(config.ADMIN_CHAT_HISTORY_PATH);
+    const result = await runtime.api.fileRead({
+      path: config.ADMIN_CHAT_HISTORY_PATH,
+      allowMissing: true
+    });
+    if (result && result.exists === false) {
+      return [];
+    }
     const parsed = JSON.parse(String(result?.content || "[]"));
     return Array.isArray(parsed) ? parsed : [];
   } catch (error) {

--- a/app/L0/_all/mod/_core/admin/views/agent/store.js
+++ b/app/L0/_all/mod/_core/admin/views/agent/store.js
@@ -480,6 +480,22 @@ const model = {
     return config.normalizeAdminChatLlmProvider(this.settingsDraft.provider) === config.ADMIN_CHAT_LLM_PROVIDER.API;
   },
 
+  get isSettingsDraftUsingBedrockProvider() {
+    return config.normalizeAdminChatLlmProvider(this.settingsDraft.provider) === config.ADMIN_CHAT_LLM_PROVIDER.BEDROCK;
+  },
+
+  get isSettingsDraftUsingBedrockClientKey() {
+    return config.normalizeAdminChatBedrockCredMode(this.settingsDraft.bedrockCredMode) === config.ADMIN_CHAT_BEDROCK_CRED_MODE.CLIENT_KEY;
+  },
+
+  get bedrockModelPresets() {
+    return config.BEDROCK_MODEL_PRESETS;
+  },
+
+  get bedrockServerConfig() {
+    return this.bedrockServerConfigState || null;
+  },
+
   get isSettingsDraftUsingLocalProvider() {
     return config.normalizeAdminChatLlmProvider(this.settingsDraft.provider) === config.ADMIN_CHAT_LLM_PROVIDER.LOCAL;
   },
@@ -1635,6 +1651,11 @@ const model = {
   openSettingsDialog() {
     this.settingsDraft = {
       ...this.settings,
+      bedrockApiKey: this.settings.bedrockApiKey || "",
+      bedrockCredMode:
+        this.settings.bedrockCredMode || config.DEFAULT_ADMIN_CHAT_SETTINGS.bedrockCredMode,
+      bedrockModel:
+        this.settings.bedrockModel || config.DEFAULT_ADMIN_CHAT_SETTINGS.bedrockModel,
       promptBudgetRatios: clonePromptBudgetRatios(this.settings.promptBudgetRatios)
     };
     this.syncHuggingFaceFromManager();
@@ -1648,7 +1669,50 @@ const model = {
       .catch((error) => {
         this.reportError("warming the local-provider settings draft", error);
       });
+
+    void this.loadBedrockServerConfig().catch((error) => {
+      this.reportError("loading Bedrock server config", error);
+    });
+
     openDialog(this.refs.settingsDialog);
+  },
+
+  async loadBedrockServerConfig() {
+    try {
+      const response = await fetch("/api/bedrock/config", {
+        credentials: "same-origin"
+      });
+      if (!response.ok) {
+        this.bedrockServerConfigState = { error: `HTTP ${response.status}` };
+        return;
+      }
+      const body = await response.json();
+      this.bedrockServerConfigState = {
+        error: null,
+        hasApiKey: Boolean(body.hasApiKey),
+        mode: body.mode || "unknown",
+        profile: body.profile || "",
+        region: body.region || ""
+      };
+    } catch (error) {
+      this.bedrockServerConfigState = {
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  },
+
+  setSettingsBedrockCredMode(mode) {
+    this.settingsDraft = {
+      ...this.settingsDraft,
+      bedrockCredMode: config.normalizeAdminChatBedrockCredMode(mode)
+    };
+  },
+
+  setSettingsBedrockModel(modelId) {
+    this.settingsDraft = {
+      ...this.settingsDraft,
+      bedrockModel: String(modelId || "").trim()
+    };
   },
 
   closeSettingsDialog() {
@@ -1856,6 +1920,12 @@ const model = {
     const localProvider = config.normalizeAdminChatLocalProvider(this.settingsDraft.localProvider);
     const paramsText = typeof this.settingsDraft.paramsText === "string" ? this.settingsDraft.paramsText.trim() : "";
     let maxTokens = config.DEFAULT_ADMIN_CHAT_SETTINGS.maxTokens;
+    let effectiveApiEndpoint = (this.settingsDraft.apiEndpoint || "").trim();
+    let effectiveApiKey = (this.settingsDraft.apiKey || "").trim();
+    let effectiveModel = (this.settingsDraft.model || "").trim();
+    const effectiveBedrockCredMode = config.normalizeAdminChatBedrockCredMode(this.settingsDraft.bedrockCredMode);
+    const effectiveBedrockApiKey = (this.settingsDraft.bedrockApiKey || "").trim();
+    const effectiveBedrockModel = (this.settingsDraft.bedrockModel || config.DEFAULT_ADMIN_CHAT_SETTINGS.bedrockModel || "").trim();
 
     try {
       maxTokens = config.parseAdminChatMaxTokens(this.settingsDraft.maxTokens);
@@ -1869,19 +1939,41 @@ const model = {
           throw new Error("Choose a Hugging Face model and dtype before saving.");
         }
       }
+
+      if (provider === config.ADMIN_CHAT_LLM_PROVIDER.BEDROCK) {
+        if (!effectiveBedrockModel) {
+          throw new Error("Pick a Bedrock model before saving.");
+        }
+        if (
+          effectiveBedrockCredMode === config.ADMIN_CHAT_BEDROCK_CRED_MODE.CLIENT_KEY &&
+          !effectiveBedrockApiKey
+        ) {
+          throw new Error("Paste a Bedrock API key, or switch to the server-side credential mode.");
+        }
+        const route = config.bedrockRouteForModel(effectiveBedrockModel);
+        effectiveApiEndpoint = config.bedrockApiEndpointForRoute(route);
+        effectiveApiKey =
+          effectiveBedrockCredMode === config.ADMIN_CHAT_BEDROCK_CRED_MODE.CLIENT_KEY
+            ? effectiveBedrockApiKey
+            : "local";
+        effectiveModel = effectiveBedrockModel;
+      }
     } catch (error) {
       this.reportError("validating admin chat settings", error);
       return;
     }
 
     this.settings = {
-      apiEndpoint: (this.settingsDraft.apiEndpoint || "").trim(),
-      apiKey: (this.settingsDraft.apiKey || "").trim(),
+      apiEndpoint: effectiveApiEndpoint,
+      apiKey: effectiveApiKey,
+      bedrockApiKey: effectiveBedrockApiKey,
+      bedrockCredMode: effectiveBedrockCredMode,
+      bedrockModel: effectiveBedrockModel,
       huggingfaceDtype: (this.settingsDraft.huggingfaceDtype || "").trim(),
       huggingfaceModel: normalizeHuggingFaceModelInput(this.settingsDraft.huggingfaceModel || ""),
       localProvider,
       maxTokens,
-      model: (this.settingsDraft.model || "").trim(),
+      model: effectiveModel,
       paramsText,
       promptBudgetRatios: clonePromptBudgetRatios(this.settingsDraft.promptBudgetRatios),
       provider,

--- a/app/L0/_all/mod/_core/dashboard_welcome/dashboard-prefs.js
+++ b/app/L0/_all/mod/_core/dashboard_welcome/dashboard-prefs.js
@@ -93,7 +93,10 @@ export async function loadDashboardPrefs() {
   const runtime = getRuntime();
 
   try {
-    const result = await runtime.api.fileRead(DASHBOARD_CONFIG_PATH);
+    const result = await runtime.api.fileRead({ path: DASHBOARD_CONFIG_PATH, allowMissing: true });
+    if (result && result.exists === false) {
+      return normalizeDashboardPrefs({});
+    }
     return normalizeDashboardPrefs(runtime.utils.yaml.parse(String(result?.content || "")));
   } catch (error) {
     if (isMissingFileError(error)) {

--- a/app/L0/_all/mod/_core/framework/js/api-client.js
+++ b/app/L0/_all/mod/_core/framework/js/api-client.js
@@ -362,23 +362,21 @@ function createFileReadRequest(pathOrFiles, encoding) {
   }
 
   if (isPlainObject(pathOrFiles) && Array.isArray(pathOrFiles.files)) {
-    return {
-      method: "POST",
-      body: {
-        encoding: pathOrFiles.encoding ?? encoding,
-        files: pathOrFiles.files
-      }
+    const body = {
+      encoding: pathOrFiles.encoding ?? encoding,
+      files: pathOrFiles.files
     };
+    if (pathOrFiles.allowMissing === true) body.allowMissing = true;
+    return { method: "POST", body };
   }
 
   if (isPlainObject(pathOrFiles) && typeof pathOrFiles.path === "string") {
-    return {
-      method: "POST",
-      body: {
-        encoding: pathOrFiles.encoding ?? encoding,
-        path: pathOrFiles.path
-      }
+    const body = {
+      encoding: pathOrFiles.encoding ?? encoding,
+      path: pathOrFiles.path
     };
+    if (pathOrFiles.allowMissing === true) body.allowMissing = true;
+    return { method: "POST", body };
   }
 
   return {

--- a/app/L0/_all/mod/_core/llm_settings/panel.html
+++ b/app/L0/_all/mod/_core/llm_settings/panel.html
@@ -1,0 +1,157 @@
+<style>
+  .llm-settings-panel .field select {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    padding: 0.85rem 0.95rem;
+    box-sizing: border-box;
+    border: 1px solid var(--space-field-border);
+    border-radius: 1rem;
+    background: var(--space-field-bg);
+    color: var(--color-text);
+    font: inherit;
+    outline: none;
+  }
+  .llm-settings-panel .field select:focus {
+    border-color: var(--space-field-focus-border);
+    box-shadow: 0 0 0 3px var(--space-field-focus-ring);
+  }
+  .llm-settings-panel .field-note {
+    margin: 0.35rem 0 0;
+  }
+  .llm-settings-panel ul.field-note {
+    padding-left: 1.2em;
+  }
+</style>
+
+<div
+  class="llm-settings-panel"
+  x-data="{
+    mode: xAttrs($el).mode || 'onscreen',
+    get s() { return $store[this.mode === 'admin' ? 'adminAgent' : 'onscreenAgent']; },
+    get hfComponentMode() { return this.mode === 'admin' ? 'admin' : 'onscreen'; }
+  }"
+>
+  <div class="dialog-segmented-control" role="tablist" aria-label="LLM provider">
+    <button
+      type="button"
+      class="secondary-button dialog-segmented-button"
+      :class="{ 'is-active': s.isSettingsDraftUsingApiProvider }"
+      @click="s.setSettingsProvider('api')"
+    >
+      <span>API</span>
+    </button>
+    <button
+      type="button"
+      class="secondary-button dialog-segmented-button"
+      :class="{ 'is-active': s.isSettingsDraftUsingBedrockProvider }"
+      @click="s.setSettingsProvider('bedrock')"
+    >
+      <span>Bedrock</span>
+    </button>
+    <button
+      type="button"
+      class="secondary-button dialog-segmented-button"
+      :class="{ 'is-active': s.isSettingsDraftUsingLocalProvider }"
+      @click="s.setSettingsProvider('local')"
+    >
+      <span>Local</span>
+    </button>
+  </div>
+
+  <!-- API tab -->
+  <div x-show="s.isSettingsDraftUsingApiProvider" x-cloak>
+    <label class="field">
+      <span>Provider API Endpoint URL</span>
+      <input type="url" x-model="s.settingsDraft.apiEndpoint" />
+    </label>
+    <label class="field">
+      <span>Model Name</span>
+      <input type="text" x-model="s.settingsDraft.model" />
+    </label>
+    <label class="field">
+      <span>API Key</span>
+      <input type="password" x-model="s.settingsDraft.apiKey" />
+    </label>
+  </div>
+
+  <!-- Bedrock tab -->
+  <div x-show="s.isSettingsDraftUsingBedrockProvider" x-cloak>
+    <div class="field" x-show="s.bedrockServerConfig">
+      <span>Server credentials</span>
+      <template x-if="s.bedrockServerConfig && !s.bedrockServerConfig.error">
+        <ul class="field-note">
+          <li>Mode: <strong x-text="s.bedrockServerConfig.mode === 'sigv4' ? 'AWS profile (SigV4)' : 'Bedrock API key'"></strong></li>
+          <li x-show="s.bedrockServerConfig.mode === 'sigv4'">
+            Profile: <code x-text="s.bedrockServerConfig.profile || '(default)'"></code>
+          </li>
+          <li>Region: <code x-text="s.bedrockServerConfig.region"></code></li>
+          <li>Set via env: <code>AWS_PROFILE</code>, <code>SPACE_BEDROCK_*</code></li>
+        </ul>
+      </template>
+      <template x-if="s.bedrockServerConfig && s.bedrockServerConfig.error">
+        <p class="field-note">
+          <code>/api/bedrock/config</code> failed: <span x-text="s.bedrockServerConfig.error"></span>
+        </p>
+      </template>
+    </div>
+
+    <div class="field">
+      <span>Credential mode</span>
+      <div class="dialog-segmented-control" role="radiogroup" aria-label="Bedrock credential mode">
+        <button
+          type="button"
+          class="secondary-button dialog-segmented-button"
+          :class="{ 'is-active': !s.isSettingsDraftUsingBedrockClientKey }"
+          @click="s.setSettingsBedrockCredMode('server')"
+          role="radio"
+          :aria-checked="!s.isSettingsDraftUsingBedrockClientKey"
+        >
+          <span>Use server credentials</span>
+        </button>
+        <button
+          type="button"
+          class="secondary-button dialog-segmented-button"
+          :class="{ 'is-active': s.isSettingsDraftUsingBedrockClientKey }"
+          @click="s.setSettingsBedrockCredMode('client-key')"
+          role="radio"
+          :aria-checked="s.isSettingsDraftUsingBedrockClientKey"
+        >
+          <span>Paste a Bedrock API key</span>
+        </button>
+      </div>
+      <ul class="field-note">
+        <li><strong>Server</strong>: Node signs with AWS profile / Bedrock key from env. Works for all models.</li>
+        <li><strong>Pasted key</strong>: Bearer token. <code>openai.gpt-oss-*</code> only (Claude needs SigV4).</li>
+      </ul>
+    </div>
+
+    <label class="field" x-show="s.isSettingsDraftUsingBedrockClientKey">
+      <span>Bedrock API Key</span>
+      <input type="password" x-model="s.settingsDraft.bedrockApiKey" autocomplete="off" />
+    </label>
+
+    <label class="field">
+      <span>Model</span>
+      <select x-model="s.settingsDraft.bedrockModel">
+        <template x-for="preset in s.bedrockModelPresets" :key="preset.id">
+          <option :value="preset.id" x-text="`${preset.label} — ${preset.id}`"></option>
+        </template>
+      </select>
+      <p class="field-note">
+        Auto-routed: <code>openai.*</code> → <code>/openai/v1/chat/completions</code>; else → <code>/converse/v1/chat/completions</code>.
+      </p>
+    </label>
+  </div>
+
+  <!-- Local tab -->
+  <div x-show="s.isSettingsDraftUsingLocalProvider" x-cloak>
+    <template x-if="hfComponentMode === 'admin'">
+      <x-component path="/mod/_core/huggingface/config-sidebar.html" mode="admin"></x-component>
+    </template>
+    <template x-if="hfComponentMode === 'onscreen'">
+      <x-component path="/mod/_core/huggingface/config-sidebar.html" mode="onscreen"></x-component>
+    </template>
+  </div>
+</div>

--- a/app/L0/_all/mod/_core/onscreen_agent/config.js
+++ b/app/L0/_all/mod/_core/onscreen_agent/config.js
@@ -6,8 +6,42 @@ export const ONSCREEN_AGENT_UI_STATE_STORAGE_KEY = "space.onscreenAgent.uiState"
 export const DEFAULT_ONSCREEN_AGENT_MAX_TOKENS = 120_000;
 export const ONSCREEN_AGENT_LLM_PROVIDER = Object.freeze({
   API: "api",
+  BEDROCK: "bedrock",
   LOCAL: "local"
 });
+
+export const ONSCREEN_AGENT_BEDROCK_CRED_MODE = Object.freeze({
+  SERVER: "server",
+  CLIENT_KEY: "client-key"
+});
+
+export const ONSCREEN_AGENT_BEDROCK_ROUTE = Object.freeze({
+  CONVERSE: "converse",
+  OPENAI: "openai"
+});
+
+export const ONSCREEN_BEDROCK_MODEL_PRESETS = Object.freeze([
+  { id: "us.anthropic.claude-sonnet-4-6", label: "Claude Sonnet 4.6 (fast, recommended)", route: "converse" },
+  { id: "us.anthropic.claude-opus-4-7", label: "Claude Opus 4.7 (smartest)", route: "converse" },
+  { id: "us.anthropic.claude-opus-4-6-v1", label: "Claude Opus 4.6", route: "converse" },
+  { id: "us.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Claude Haiku 4.5 (cheap)", route: "converse" },
+  { id: "openai.gpt-oss-20b-1:0", label: "OpenAI gpt-oss 20B", route: "openai" },
+  { id: "openai.gpt-oss-120b-1:0", label: "OpenAI gpt-oss 120B", route: "openai" }
+]);
+
+export function bedrockRouteForOnscreenModel(modelId = "") {
+  const normalized = String(modelId || "").trim().toLowerCase();
+  if (!normalized) return ONSCREEN_AGENT_BEDROCK_ROUTE.CONVERSE;
+  return normalized.startsWith("openai.")
+    ? ONSCREEN_AGENT_BEDROCK_ROUTE.OPENAI
+    : ONSCREEN_AGENT_BEDROCK_ROUTE.CONVERSE;
+}
+
+export function bedrockApiEndpointForOnscreenRoute(route = ONSCREEN_AGENT_BEDROCK_ROUTE.CONVERSE) {
+  return route === ONSCREEN_AGENT_BEDROCK_ROUTE.OPENAI
+    ? "/api/bedrock/openai/v1/chat/completions"
+    : "/api/bedrock/converse/v1/chat/completions";
+}
 export const ONSCREEN_AGENT_LOCAL_PROVIDER = Object.freeze({
   HUGGINGFACE: "huggingface"
 });
@@ -21,6 +55,9 @@ export const ONSCREEN_AGENT_HIDDEN_EDGE = Object.freeze({
 export const DEFAULT_ONSCREEN_AGENT_SETTINGS = {
   apiEndpoint: "https://openrouter.ai/api/v1/chat/completions",
   apiKey: "",
+  bedrockApiKey: "",
+  bedrockCredMode: ONSCREEN_AGENT_BEDROCK_CRED_MODE.SERVER,
+  bedrockModel: ONSCREEN_BEDROCK_MODEL_PRESETS[0].id,
   huggingfaceDtype: "q4",
   huggingfaceModel: "",
   localProvider: ONSCREEN_AGENT_LOCAL_PROVIDER.HUGGINGFACE,
@@ -36,9 +73,15 @@ function normalizeOnscreenAgentSettingText(value) {
 }
 
 export function normalizeOnscreenAgentLlmProvider(value) {
-  return value === ONSCREEN_AGENT_LLM_PROVIDER.LOCAL
-    ? ONSCREEN_AGENT_LLM_PROVIDER.LOCAL
-    : ONSCREEN_AGENT_LLM_PROVIDER.API;
+  if (value === ONSCREEN_AGENT_LLM_PROVIDER.LOCAL) return ONSCREEN_AGENT_LLM_PROVIDER.LOCAL;
+  if (value === ONSCREEN_AGENT_LLM_PROVIDER.BEDROCK) return ONSCREEN_AGENT_LLM_PROVIDER.BEDROCK;
+  return ONSCREEN_AGENT_LLM_PROVIDER.API;
+}
+
+export function normalizeOnscreenAgentBedrockCredMode(value) {
+  return value === ONSCREEN_AGENT_BEDROCK_CRED_MODE.CLIENT_KEY
+    ? ONSCREEN_AGENT_BEDROCK_CRED_MODE.CLIENT_KEY
+    : ONSCREEN_AGENT_BEDROCK_CRED_MODE.SERVER;
 }
 
 export function normalizeOnscreenAgentLocalProvider(value) {

--- a/app/L0/_all/mod/_core/onscreen_agent/panel.html
+++ b/app/L0/_all/mod/_core/onscreen_agent/panel.html
@@ -329,43 +329,7 @@
                     </div>
                   </header>
                   <div class="dialog-scroll-body">
-                    <div class="dialog-segmented-control onscreen-agent-provider-switch" role="tablist" aria-label="LLM provider">
-                      <button
-                        type="button"
-                        class="secondary-button dialog-segmented-button"
-                        :class="{ 'is-active': $store.onscreenAgent.isSettingsDraftUsingApiProvider }"
-                        @click="$store.onscreenAgent.setSettingsProvider('api')"
-                      >
-                        <span>API</span>
-                      </button>
-                      <button
-                        type="button"
-                        class="secondary-button dialog-segmented-button"
-                        :class="{ 'is-active': $store.onscreenAgent.isSettingsDraftUsingLocalProvider }"
-                        @click="$store.onscreenAgent.setSettingsProvider('local')"
-                      >
-                        <span>Local</span>
-                      </button>
-                    </div>
-                    <div x-show="$store.onscreenAgent.isSettingsDraftUsingApiProvider" x-cloak>
-                      <label class="field">
-                        <span>Provider API Endpoint URL</span>
-                        <input type="url" x-model="$store.onscreenAgent.settingsDraft.apiEndpoint" />
-                      </label>
-                      <label class="field">
-                        <span>Model Name</span>
-                        <input type="text" x-model="$store.onscreenAgent.settingsDraft.model" />
-                      </label>
-                      <label class="field">
-                        <span>API Key</span>
-                        <input type="password" x-model="$store.onscreenAgent.settingsDraft.apiKey" />
-                      </label>
-                    </div>
-                    <div x-show="$store.onscreenAgent.isSettingsDraftUsingLocalProvider" x-cloak class="onscreen-agent-local-settings">
-                      <div class="onscreen-agent-local-provider-panel">
-                        <x-component path="/mod/_core/huggingface/config-sidebar.html" mode="onscreen"></x-component>
-                      </div>
-                    </div>
+                    <x-component path="/mod/_core/llm_settings/panel.html" mode="onscreen"></x-component>
                     <label class="field">
                       <span>Max Tokens</span>
                       <input type="number" min="1" step="1" inputmode="numeric" x-model="$store.onscreenAgent.settingsDraft.maxTokens" />

--- a/app/L0/_all/mod/_core/onscreen_agent/storage.js
+++ b/app/L0/_all/mod/_core/onscreen_agent/storage.js
@@ -349,10 +349,14 @@ export async function loadOnscreenAgentConfig() {
   const runtime = getRuntime();
 
   try {
-    const result = await runtime.api.fileRead(config.ONSCREEN_AGENT_CONFIG_PATH);
+    const result = await runtime.api.fileRead({
+      path: config.ONSCREEN_AGENT_CONFIG_PATH,
+      allowMissing: true
+    });
+    const rawContent = result && result.exists === false ? "" : String(result?.content || "");
     const normalizedConfig = await normalizeStoredConfig(
       runtime,
-      runtime.utils.yaml.parse(String(result?.content || ""))
+      runtime.utils.yaml.parse(rawContent)
     );
     const storedUiState =
       loadUiStateFromStorageArea("sessionStorage") ||
@@ -404,7 +408,13 @@ export async function loadOnscreenAgentHistory() {
   const runtime = getRuntime();
 
   try {
-    const result = await runtime.api.fileRead(config.ONSCREEN_AGENT_HISTORY_PATH);
+    const result = await runtime.api.fileRead({
+      path: config.ONSCREEN_AGENT_HISTORY_PATH,
+      allowMissing: true
+    });
+    if (result && result.exists === false) {
+      return [];
+    }
     const parsed = JSON.parse(String(result?.content || "[]"));
     return Array.isArray(parsed) ? parsed : [];
   } catch (error) {

--- a/app/L0/_all/mod/_core/onscreen_agent/store.js
+++ b/app/L0/_all/mod/_core/onscreen_agent/store.js
@@ -1620,6 +1620,22 @@ const model = {
     return config.normalizeOnscreenAgentLlmProvider(this.settingsDraft.provider) === config.ONSCREEN_AGENT_LLM_PROVIDER.LOCAL;
   },
 
+  get isSettingsDraftUsingBedrockProvider() {
+    return config.normalizeOnscreenAgentLlmProvider(this.settingsDraft.provider) === config.ONSCREEN_AGENT_LLM_PROVIDER.BEDROCK;
+  },
+
+  get isSettingsDraftUsingBedrockClientKey() {
+    return config.normalizeOnscreenAgentBedrockCredMode(this.settingsDraft.bedrockCredMode) === config.ONSCREEN_AGENT_BEDROCK_CRED_MODE.CLIENT_KEY;
+  },
+
+  get bedrockModelPresets() {
+    return config.ONSCREEN_BEDROCK_MODEL_PRESETS;
+  },
+
+  get bedrockServerConfig() {
+    return this.bedrockServerConfigState || null;
+  },
+
   get huggingfaceSavedModels() {
     return Array.isArray(this.huggingface.savedModels) ? this.huggingface.savedModels : [];
   },
@@ -4382,6 +4398,11 @@ const model = {
   openSettingsDialog() {
     this.settingsDraft = {
       ...this.settings,
+      bedrockApiKey: this.settings.bedrockApiKey || "",
+      bedrockCredMode:
+        this.settings.bedrockCredMode || config.DEFAULT_ONSCREEN_AGENT_SETTINGS.bedrockCredMode,
+      bedrockModel:
+        this.settings.bedrockModel || config.DEFAULT_ONSCREEN_AGENT_SETTINGS.bedrockModel,
       promptBudgetRatios: clonePromptBudgetRatios(this.settings.promptBudgetRatios)
     };
     this.syncHuggingFaceFromManager();
@@ -4398,7 +4419,48 @@ const model = {
         preserveStatus: true
       });
     });
+
+    void this.loadBedrockServerConfig().catch((error) => {
+      this.reportError("loading Bedrock server config", error, { preserveStatus: true });
+    });
+
     openDialog(resolveDialogRef(this.refs, "settingsDialog", SETTINGS_DIALOG_ELEMENT_ID));
+  },
+
+  async loadBedrockServerConfig() {
+    try {
+      const response = await fetch("/api/bedrock/config", { credentials: "same-origin" });
+      if (!response.ok) {
+        this.bedrockServerConfigState = { error: `HTTP ${response.status}` };
+        return;
+      }
+      const body = await response.json();
+      this.bedrockServerConfigState = {
+        error: null,
+        hasApiKey: Boolean(body.hasApiKey),
+        mode: body.mode || "unknown",
+        profile: body.profile || "",
+        region: body.region || ""
+      };
+    } catch (error) {
+      this.bedrockServerConfigState = {
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  },
+
+  setSettingsBedrockCredMode(mode) {
+    this.settingsDraft = {
+      ...this.settingsDraft,
+      bedrockCredMode: config.normalizeOnscreenAgentBedrockCredMode(mode)
+    };
+  },
+
+  setSettingsBedrockModel(modelId) {
+    this.settingsDraft = {
+      ...this.settingsDraft,
+      bedrockModel: String(modelId || "").trim()
+    };
   },
 
   closeSettingsDialog() {
@@ -4567,6 +4629,12 @@ const model = {
     const paramsText = typeof this.settingsDraft.paramsText === "string" ? this.settingsDraft.paramsText.trim() : "";
     const draftPrompt = typeof this.systemPromptDraft === "string" ? this.systemPromptDraft.trim() : "";
     let maxTokens = config.DEFAULT_ONSCREEN_AGENT_SETTINGS.maxTokens;
+    let effectiveApiEndpoint = (this.settingsDraft.apiEndpoint || "").trim();
+    let effectiveApiKey = (this.settingsDraft.apiKey || "").trim();
+    let effectiveModel = (this.settingsDraft.model || "").trim();
+    const effectiveBedrockCredMode = config.normalizeOnscreenAgentBedrockCredMode(this.settingsDraft.bedrockCredMode);
+    const effectiveBedrockApiKey = (this.settingsDraft.bedrockApiKey || "").trim();
+    const effectiveBedrockModel = (this.settingsDraft.bedrockModel || config.DEFAULT_ONSCREEN_AGENT_SETTINGS.bedrockModel || "").trim();
 
     try {
       maxTokens = config.parseOnscreenAgentMaxTokens(this.settingsDraft.maxTokens);
@@ -4580,6 +4648,25 @@ const model = {
           throw new Error("Choose a Hugging Face model and dtype before saving.");
         }
       }
+
+      if (provider === config.ONSCREEN_AGENT_LLM_PROVIDER.BEDROCK) {
+        if (!effectiveBedrockModel) {
+          throw new Error("Pick a Bedrock model before saving.");
+        }
+        if (
+          effectiveBedrockCredMode === config.ONSCREEN_AGENT_BEDROCK_CRED_MODE.CLIENT_KEY &&
+          !effectiveBedrockApiKey
+        ) {
+          throw new Error("Paste a Bedrock API key, or switch to the server-side credential mode.");
+        }
+        const route = config.bedrockRouteForOnscreenModel(effectiveBedrockModel);
+        effectiveApiEndpoint = config.bedrockApiEndpointForOnscreenRoute(route);
+        effectiveApiKey =
+          effectiveBedrockCredMode === config.ONSCREEN_AGENT_BEDROCK_CRED_MODE.CLIENT_KEY
+            ? effectiveBedrockApiKey
+            : "local";
+        effectiveModel = effectiveBedrockModel;
+      }
     } catch (error) {
       this.reportError("validating chat settings", error, {
         preserveStatus: true
@@ -4588,13 +4675,16 @@ const model = {
     }
 
     this.settings = {
-      apiEndpoint: (this.settingsDraft.apiEndpoint || "").trim(),
-      apiKey: (this.settingsDraft.apiKey || "").trim(),
+      apiEndpoint: effectiveApiEndpoint,
+      apiKey: effectiveApiKey,
+      bedrockApiKey: effectiveBedrockApiKey,
+      bedrockCredMode: effectiveBedrockCredMode,
+      bedrockModel: effectiveBedrockModel,
       huggingfaceDtype: (this.settingsDraft.huggingfaceDtype || "").trim(),
       huggingfaceModel: normalizeHuggingFaceModelInput(this.settingsDraft.huggingfaceModel || ""),
       localProvider,
       maxTokens,
-      model: (this.settingsDraft.model || "").trim(),
+      model: effectiveModel,
       paramsText,
       promptBudgetRatios: clonePromptBudgetRatios(this.settingsDraft.promptBudgetRatios),
       provider,

--- a/server/api/file_read.js
+++ b/server/api/file_read.js
@@ -17,12 +17,39 @@ function readEncoding(context) {
   return String(payload.encoding || context.params.encoding || "utf8");
 }
 
+function readAllowMissing(context) {
+  const payload = readPayload(context);
+  const raw =
+    payload.allowMissing ??
+    payload.allow_missing ??
+    context.params.allowMissing ??
+    context.params.allow_missing;
+  return raw === true || raw === "true" || raw === "1" || raw === 1;
+}
+
+function isMissingPathError(error) {
+  const status = Number(error?.statusCode);
+  if (status === 404) return true;
+  const code = typeof error?.code === "string" ? error.code.toUpperCase() : "";
+  return code === "ENOENT" || /path not found|not found/iu.test(String(error?.message || ""));
+}
+
 function hasBatchRead(payload) {
   return Boolean(payload) && typeof payload === "object" && Array.isArray(payload.files);
 }
 
+function buildMissingFileResult(path, encoding) {
+  return {
+    content: encoding === "base64" ? "" : "",
+    encoding,
+    exists: false,
+    path: String(path || "")
+  };
+}
+
 function handleRead(context) {
   const payload = readPayload(context);
+  const allowMissing = readAllowMissing(context);
   const maxLayer = resolveRequestMaxLayer({
     body: payload,
     headers: context.headers,
@@ -41,13 +68,33 @@ function handleRead(context) {
     };
 
     if (hasBatchRead(payload)) {
+      if (allowMissing) {
+        const files = payload.files.map((entry) => {
+          try {
+            return readAppFile({ ...options, path: entry.path, encoding: entry.encoding || options.encoding });
+          } catch (error) {
+            if (isMissingPathError(error)) {
+              return buildMissingFileResult(entry.path, entry.encoding || options.encoding);
+            }
+            throw error;
+          }
+        });
+        return { files };
+      }
       return readAppFiles({
         ...options,
         files: payload.files
       });
     }
 
-    return readAppFile(options);
+    try {
+      return readAppFile(options);
+    } catch (error) {
+      if (allowMissing && isMissingPathError(error)) {
+        return buildMissingFileResult(options.path, options.encoding);
+      }
+      throw error;
+    }
   } catch (error) {
     throw createHttpError(error.message || "File read failed.", Number(error.statusCode) || 500);
   }

--- a/server/lib/bedrock/converse.js
+++ b/server/lib/bedrock/converse.js
@@ -1,0 +1,371 @@
+import { randomUUID } from "node:crypto";
+import { Readable } from "node:stream";
+
+import { EventStreamDecoder } from "./eventstream.js";
+import { resolveBedrockCredentials, signBedrockRequest } from "./sigv4.js";
+
+const DEFAULT_MAX_TOKENS = 4096;
+
+function extractText(content) {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+      if (part && typeof part.text === "string") {
+        return part.text;
+      }
+      return "";
+    })
+    .join("");
+}
+
+function translateOpenAiMessages(openaiPayload) {
+  const messages = Array.isArray(openaiPayload?.messages) ? openaiPayload.messages : [];
+  const systemParts = [];
+  const converseMessages = [];
+
+  for (const message of messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+
+    const text = extractText(message.content);
+
+    if (!text) {
+      continue;
+    }
+
+    if (message.role === "system") {
+      systemParts.push({ text });
+      continue;
+    }
+
+    if (message.role === "user" || message.role === "assistant") {
+      converseMessages.push({
+        role: message.role,
+        content: [{ text }]
+      });
+    }
+  }
+
+  return { converseMessages, systemParts };
+}
+
+function modelRejectsTemperature(modelId) {
+  const normalized = String(modelId || "").toLowerCase();
+  if (!normalized.includes("anthropic")) return false;
+  // Claude 4.5+ (sonnet/opus/haiku) deprecates temperature and top_p on
+  // Bedrock Converse. Strip both for those models; pass through for everything else.
+  return /claude-(opus-4-[6-9]|opus-4-[1-9]\d|sonnet-4-[6-9]|sonnet-4-[1-9]\d|haiku-4-[5-9]|haiku-4-[1-9]\d)/u.test(normalized);
+}
+
+function buildInferenceConfig(openaiPayload) {
+  const config = {};
+  const dropTempAndTopP = modelRejectsTemperature(openaiPayload?.model);
+
+  const maxTokens = Number(openaiPayload?.max_tokens ?? openaiPayload?.max_completion_tokens);
+  config.maxTokens = Number.isFinite(maxTokens) && maxTokens > 0 ? maxTokens : DEFAULT_MAX_TOKENS;
+
+  const temperature = Number(openaiPayload?.temperature);
+  if (!dropTempAndTopP && Number.isFinite(temperature)) {
+    config.temperature = temperature;
+  }
+
+  const topP = Number(openaiPayload?.top_p);
+  if (!dropTempAndTopP && Number.isFinite(topP)) {
+    config.topP = topP;
+  }
+
+  const stopRaw = openaiPayload?.stop;
+  const stopSequences = Array.isArray(stopRaw)
+    ? stopRaw.filter((value) => typeof value === "string" && value.length)
+    : typeof stopRaw === "string" && stopRaw.length
+      ? [stopRaw]
+      : [];
+
+  if (stopSequences.length) {
+    config.stopSequences = stopSequences;
+  }
+
+  return config;
+}
+
+function buildConverseBody(openaiPayload) {
+  const { converseMessages, systemParts } = translateOpenAiMessages(openaiPayload);
+
+  const body = {
+    messages: converseMessages,
+    inferenceConfig: buildInferenceConfig(openaiPayload)
+  };
+
+  if (systemParts.length) {
+    body.system = systemParts;
+  }
+
+  return body;
+}
+
+function mapStopReason(reason) {
+  if (!reason) {
+    return "stop";
+  }
+
+  switch (reason) {
+    case "end_turn":
+    case "stop_sequence":
+      return "stop";
+    case "max_tokens":
+      return "length";
+    case "tool_use":
+      return "tool_calls";
+    case "content_filtered":
+      return "content_filter";
+    default:
+      return "stop";
+  }
+}
+
+function formatOpenAiSseChunk({ content, created, finishReason, id, model }) {
+  const payload = {
+    id,
+    object: "chat.completion.chunk",
+    created,
+    model,
+    choices: [
+      {
+        index: 0,
+        delta: content ? { content } : {},
+        finish_reason: finishReason || null
+      }
+    ]
+  };
+
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+function formatOpenAiCompletion({ created, finishReason, id, model, text, usage }) {
+  return {
+    id,
+    object: "chat.completion",
+    created,
+    model,
+    choices: [
+      {
+        index: 0,
+        finish_reason: finishReason || "stop",
+        message: {
+          role: "assistant",
+          content: text
+        }
+      }
+    ],
+    usage: usage || undefined
+  };
+}
+
+async function executeSignedBedrockRequest({ body, method, path, region, streamResponse }) {
+  const credentials = await resolveBedrockCredentials();
+  const url = new URL(`https://bedrock-runtime.${region}.amazonaws.com${path}`);
+  const bodyBuffer = Buffer.from(JSON.stringify(body), "utf8");
+
+  const signed = signBedrockRequest({
+    body: bodyBuffer,
+    credentials,
+    headers: {
+      "content-type": "application/json",
+      accept: streamResponse ? "application/vnd.amazon.eventstream" : "application/json"
+    },
+    method,
+    region,
+    url
+  });
+
+  const upstream = await fetch(url, {
+    body: signed.body,
+    headers: signed.headers,
+    method
+  });
+
+  return upstream;
+}
+
+async function streamConverseToOpenAiSse(req, res, { openaiPayload, region }) {
+  const modelId = String(openaiPayload?.model || "").trim();
+
+  if (!modelId) {
+    throw new Error("A Bedrock model ID is required (set the `model` field in the request body).");
+  }
+
+  const body = buildConverseBody(openaiPayload);
+  const path = `/model/${encodeURIComponent(modelId)}/converse-stream`;
+
+  const upstream = await executeSignedBedrockRequest({
+    body,
+    method: "POST",
+    path,
+    region,
+    streamResponse: true
+  });
+
+  if (!upstream.ok) {
+    const text = await upstream.text();
+    res.writeHead(upstream.status, { "content-type": "application/json; charset=utf-8" });
+    res.end(
+      JSON.stringify({
+        error: {
+          message: `Bedrock converse-stream failed (${upstream.status}): ${text}`,
+          type: "bedrock_error"
+        }
+      })
+    );
+    return;
+  }
+
+  res.writeHead(200, {
+    "content-type": "text/event-stream; charset=utf-8",
+    "cache-control": "no-cache",
+    connection: "keep-alive"
+  });
+
+  const id = `chatcmpl-${randomUUID()}`;
+  const created = Math.floor(Date.now() / 1000);
+  const model = modelId;
+  const decoder = new EventStreamDecoder();
+  let finishReason = null;
+
+  const nodeStream = Readable.fromWeb(upstream.body);
+
+  await new Promise((resolve, reject) => {
+    nodeStream.on("data", (chunk) => {
+      try {
+        const frames = decoder.push(chunk);
+
+        for (const frame of frames) {
+          const eventType = frame.headers?.[":event-type"];
+          const messageType = frame.headers?.[":message-type"];
+
+          if (messageType === "exception" || messageType === "error") {
+            const errText = frame.payload.toString("utf8");
+            res.write(formatOpenAiSseChunk({
+              created,
+              finishReason: "stop",
+              id,
+              model,
+              content: `[Bedrock error] ${errText}`
+            }));
+            continue;
+          }
+
+          if (!frame.payload.length) {
+            continue;
+          }
+
+          const event = JSON.parse(frame.payload.toString("utf8"));
+
+          if (eventType === "contentBlockDelta") {
+            const text = event?.delta?.text || "";
+            if (text) {
+              res.write(formatOpenAiSseChunk({ content: text, created, id, model }));
+            }
+          } else if (eventType === "messageStop") {
+            finishReason = mapStopReason(event?.stopReason);
+            res.write(formatOpenAiSseChunk({ created, finishReason, id, model }));
+          }
+        }
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    nodeStream.on("error", reject);
+    nodeStream.on("end", () => {
+      if (!finishReason) {
+        res.write(formatOpenAiSseChunk({ created, finishReason: "stop", id, model }));
+      }
+      res.write("data: [DONE]\n\n");
+      res.end();
+      resolve();
+    });
+  });
+}
+
+async function converseNonStreaming(res, { openaiPayload, region }) {
+  const modelId = String(openaiPayload?.model || "").trim();
+
+  if (!modelId) {
+    throw new Error("A Bedrock model ID is required (set the `model` field in the request body).");
+  }
+
+  const body = buildConverseBody(openaiPayload);
+  const path = `/model/${encodeURIComponent(modelId)}/converse`;
+
+  const upstream = await executeSignedBedrockRequest({
+    body,
+    method: "POST",
+    path,
+    region,
+    streamResponse: false
+  });
+
+  const rawText = await upstream.text();
+
+  if (!upstream.ok) {
+    res.writeHead(upstream.status, { "content-type": "application/json; charset=utf-8" });
+    res.end(
+      JSON.stringify({
+        error: {
+          message: `Bedrock converse failed (${upstream.status}): ${rawText}`,
+          type: "bedrock_error"
+        }
+      })
+    );
+    return;
+  }
+
+  const parsed = JSON.parse(rawText);
+  const text = (parsed?.output?.message?.content || [])
+    .map((part) => (part && typeof part.text === "string" ? part.text : ""))
+    .join("");
+
+  const usage = parsed?.usage
+    ? {
+        prompt_tokens: parsed.usage.inputTokens ?? 0,
+        completion_tokens: parsed.usage.outputTokens ?? 0,
+        total_tokens: parsed.usage.totalTokens ?? 0
+      }
+    : undefined;
+
+  const completion = formatOpenAiCompletion({
+    created: Math.floor(Date.now() / 1000),
+    finishReason: mapStopReason(parsed?.stopReason),
+    id: `chatcmpl-${randomUUID()}`,
+    model: modelId,
+    text,
+    usage
+  });
+
+  const responseBody = JSON.stringify(completion);
+  res.writeHead(200, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(responseBody)
+  });
+  res.end(responseBody);
+}
+
+export async function handleConverseOpenAiRequest(req, res, { openaiPayload, region }) {
+  if (openaiPayload?.stream) {
+    await streamConverseToOpenAiSse(req, res, { openaiPayload, region });
+    return;
+  }
+
+  await converseNonStreaming(res, { openaiPayload, region });
+}

--- a/server/lib/bedrock/eventstream.js
+++ b/server/lib/bedrock/eventstream.js
@@ -1,0 +1,115 @@
+// Minimal decoder for AWS application/vnd.amazon.eventstream binary framing.
+// We only care about extracting each frame's payload and its :event-type header.
+
+const HEADER_TYPE_TRUE = 0;
+const HEADER_TYPE_FALSE = 1;
+const HEADER_TYPE_BYTE = 2;
+const HEADER_TYPE_SHORT = 3;
+const HEADER_TYPE_INTEGER = 4;
+const HEADER_TYPE_LONG = 5;
+const HEADER_TYPE_BYTE_ARRAY = 6;
+const HEADER_TYPE_STRING = 7;
+const HEADER_TYPE_TIMESTAMP = 8;
+const HEADER_TYPE_UUID = 9;
+
+function parseHeaders(buffer) {
+  const headers = {};
+  let offset = 0;
+
+  while (offset < buffer.length) {
+    const nameLen = buffer.readUInt8(offset);
+    offset += 1;
+    const name = buffer.slice(offset, offset + nameLen).toString("utf8");
+    offset += nameLen;
+    const type = buffer.readUInt8(offset);
+    offset += 1;
+
+    switch (type) {
+      case HEADER_TYPE_TRUE:
+        headers[name] = true;
+        break;
+      case HEADER_TYPE_FALSE:
+        headers[name] = false;
+        break;
+      case HEADER_TYPE_BYTE:
+        headers[name] = buffer.readInt8(offset);
+        offset += 1;
+        break;
+      case HEADER_TYPE_SHORT:
+        headers[name] = buffer.readInt16BE(offset);
+        offset += 2;
+        break;
+      case HEADER_TYPE_INTEGER:
+        headers[name] = buffer.readInt32BE(offset);
+        offset += 4;
+        break;
+      case HEADER_TYPE_LONG:
+        headers[name] = Number(buffer.readBigInt64BE(offset));
+        offset += 8;
+        break;
+      case HEADER_TYPE_BYTE_ARRAY: {
+        const len = buffer.readUInt16BE(offset);
+        offset += 2;
+        headers[name] = buffer.slice(offset, offset + len);
+        offset += len;
+        break;
+      }
+      case HEADER_TYPE_STRING: {
+        const len = buffer.readUInt16BE(offset);
+        offset += 2;
+        headers[name] = buffer.slice(offset, offset + len).toString("utf8");
+        offset += len;
+        break;
+      }
+      case HEADER_TYPE_TIMESTAMP:
+        headers[name] = Number(buffer.readBigInt64BE(offset));
+        offset += 8;
+        break;
+      case HEADER_TYPE_UUID:
+        headers[name] = buffer.slice(offset, offset + 16).toString("hex");
+        offset += 16;
+        break;
+      default:
+        throw new Error(`Unsupported eventstream header type: ${type}`);
+    }
+  }
+
+  return headers;
+}
+
+export class EventStreamDecoder {
+  constructor() {
+    this.buffer = Buffer.alloc(0);
+  }
+
+  push(chunk) {
+    if (!chunk || !chunk.length) {
+      return [];
+    }
+
+    this.buffer = this.buffer.length ? Buffer.concat([this.buffer, chunk]) : Buffer.from(chunk);
+
+    const frames = [];
+
+    while (this.buffer.length >= 12) {
+      const totalLength = this.buffer.readUInt32BE(0);
+      const headersLength = this.buffer.readUInt32BE(4);
+
+      if (this.buffer.length < totalLength) {
+        break;
+      }
+
+      const headersStart = 12;
+      const headersEnd = headersStart + headersLength;
+      const payloadEnd = totalLength - 4;
+      const headers = parseHeaders(this.buffer.slice(headersStart, headersEnd));
+      const payload = this.buffer.slice(headersEnd, payloadEnd);
+
+      frames.push({ headers, payload });
+
+      this.buffer = this.buffer.slice(totalLength);
+    }
+
+    return frames;
+  }
+}

--- a/server/lib/bedrock/proxy.js
+++ b/server/lib/bedrock/proxy.js
@@ -1,0 +1,164 @@
+import { Readable } from "node:stream";
+
+import { handleConverseOpenAiRequest } from "./converse.js";
+import { resolveBedrockCredentials, signBedrockRequest } from "./sigv4.js";
+
+const DEFAULT_REGION = "us-east-1";
+
+function readBedrockConfig() {
+  const mode = (process.env.SPACE_BEDROCK_MODE || "").toLowerCase();
+  const apiKey = (process.env.SPACE_BEDROCK_API_KEY || "").trim();
+  const profile = (process.env.SPACE_BEDROCK_AWS_PROFILE || process.env.AWS_PROFILE || "").trim();
+  const region =
+    (process.env.SPACE_BEDROCK_REGION || process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || DEFAULT_REGION).trim();
+
+  const resolvedMode = mode || (apiKey ? "apikey" : "sigv4");
+
+  return { apiKey, mode: resolvedMode, profile, region };
+}
+
+function readIncomingBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+
+    req.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+function buildUpstreamUrl(region, subPath) {
+  const trimmed = (subPath || "").replace(/^\/+/u, "");
+  const pathSegment = trimmed ? `/${trimmed}` : "/openai/v1/chat/completions";
+  return new URL(`https://bedrock-runtime.${region}.amazonaws.com${pathSegment}`);
+}
+
+function sendJsonError(res, status, message, extra = {}) {
+  const body = JSON.stringify({ error: { message, ...extra } });
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(body)
+  });
+  res.end(body);
+}
+
+function filterUpstreamHeaders(upstreamHeaders) {
+  const out = {};
+  upstreamHeaders.forEach((value, name) => {
+    const lower = name.toLowerCase();
+    if (lower === "content-encoding" || lower === "content-length" || lower === "transfer-encoding" || lower === "connection") {
+      return;
+    }
+    out[name] = value;
+  });
+  return out;
+}
+
+async function forwardResponse(res, upstream) {
+  res.writeHead(upstream.status, filterUpstreamHeaders(upstream.headers));
+
+  if (!upstream.body) {
+    res.end();
+    return;
+  }
+
+  await new Promise((resolve, reject) => {
+    const nodeStream = Readable.fromWeb(upstream.body);
+    nodeStream.on("error", reject);
+    res.on("error", reject);
+    res.on("close", resolve);
+    res.on("finish", resolve);
+    nodeStream.pipe(res);
+  });
+}
+
+export async function handleBedrockRequest(req, res, requestUrl) {
+  const method = String(req.method || "GET").toUpperCase();
+
+  if (method === "GET" && requestUrl.pathname === "/api/bedrock/config") {
+    const cfg = readBedrockConfig();
+    const body = JSON.stringify({
+      mode: cfg.mode,
+      profile: cfg.mode === "sigv4" ? cfg.profile || "default" : null,
+      region: cfg.region,
+      hasApiKey: Boolean(cfg.apiKey)
+    });
+    res.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+    res.end(body);
+    return;
+  }
+
+  if (method !== "POST") {
+    sendJsonError(res, 405, `Method ${method} is not supported for ${requestUrl.pathname}`);
+    return;
+  }
+
+  const config = readBedrockConfig();
+  const subPath = requestUrl.pathname.replace(/^\/api\/bedrock/u, "");
+  const rawBody = await readIncomingBody(req);
+
+  if (/^\/converse\/v1\/chat\/completions\/?$/u.test(subPath)) {
+    try {
+      const openaiPayload = rawBody.length ? JSON.parse(rawBody.toString("utf8")) : {};
+      await handleConverseOpenAiRequest(req, res, { openaiPayload, region: config.region });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      sendJsonError(res, 500, `Bedrock converse error: ${message}`);
+    }
+    return;
+  }
+
+  const upstreamUrl = buildUpstreamUrl(config.region, subPath);
+
+  const outgoingHeaders = {
+    "content-type": req.headers["content-type"] || "application/json",
+    accept: req.headers.accept || "application/json, text/event-stream"
+  };
+
+  const rawClientAuth = req.headers["authorization"] || req.headers["Authorization"] || "";
+  const clientBearer =
+    typeof rawClientAuth === "string" && rawClientAuth.toLowerCase().startsWith("bearer ")
+      ? rawClientAuth.slice(7).trim()
+      : "";
+  const clientProvidedRealKey = clientBearer && clientBearer.toLowerCase() !== "local";
+
+  try {
+    let finalHeaders = outgoingHeaders;
+    let finalBody = rawBody;
+
+    if (clientProvidedRealKey && /^\/openai\//u.test(subPath)) {
+      finalHeaders.authorization = `Bearer ${clientBearer}`;
+    } else if (config.mode === "apikey") {
+      if (!config.apiKey) {
+        sendJsonError(res, 500, "SPACE_BEDROCK_API_KEY is not configured.");
+        return;
+      }
+      finalHeaders.authorization = `Bearer ${config.apiKey}`;
+    } else {
+      const credentials = await resolveBedrockCredentials(config.profile);
+      const signed = signBedrockRequest({
+        body: rawBody,
+        credentials,
+        headers: outgoingHeaders,
+        method: "POST",
+        region: config.region,
+        url: upstreamUrl
+      });
+      finalHeaders = signed.headers;
+      finalBody = signed.body;
+    }
+
+    const upstream = await fetch(upstreamUrl, {
+      body: finalBody,
+      headers: finalHeaders,
+      method: "POST"
+    });
+
+    await forwardResponse(res, upstream);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    sendJsonError(res, 500, `Bedrock proxy error: ${message}`);
+  }
+}

--- a/server/lib/bedrock/sigv4.js
+++ b/server/lib/bedrock/sigv4.js
@@ -1,0 +1,242 @@
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SERVICE = "bedrock";
+
+function hmac(key, data) {
+  return crypto.createHmac("sha256", key).update(data, "utf8").digest();
+}
+
+function sha256Hex(data) {
+  return crypto.createHash("sha256").update(data || "", "utf8").digest("hex");
+}
+
+function stripInline(value) {
+  return String(value || "").replace(/\s*[;#].*$/u, "").trim();
+}
+
+function parseIniFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return {};
+  }
+
+  const text = fs.readFileSync(filePath, "utf8");
+  const sections = {};
+  let current = null;
+
+  for (const raw of text.split(/\r?\n/u)) {
+    const line = raw.replace(/^\s+/u, "");
+
+    if (!line || line.startsWith("#") || line.startsWith(";")) {
+      continue;
+    }
+
+    const sectionMatch = line.match(/^\[(.+?)\]/u);
+
+    if (sectionMatch) {
+      current = sectionMatch[1].trim();
+      sections[current] = sections[current] || {};
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    const eqIdx = line.indexOf("=");
+
+    if (eqIdx === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, eqIdx).trim();
+    const value = stripInline(line.slice(eqIdx + 1));
+
+    sections[current][key] = value;
+  }
+
+  return sections;
+}
+
+function resolveProfileSection(sections, profileName, kind) {
+  if (!profileName) {
+    return null;
+  }
+
+  if (kind === "credentials") {
+    return sections[profileName] || null;
+  }
+
+  return (
+    sections[`profile ${profileName}`] ||
+    sections[profileName] ||
+    (profileName === "default" ? sections.default : null) ||
+    null
+  );
+}
+
+function splitCredentialProcessArgs(command) {
+  const parts = [];
+  const regex = /"([^"]*)"|'([^']*)'|(\S+)/gu;
+  let match;
+  while ((match = regex.exec(command)) !== null) {
+    parts.push(match[1] ?? match[2] ?? match[3]);
+  }
+  return parts;
+}
+
+function resolveCredentialProcess(command) {
+  const args = splitCredentialProcessArgs(String(command || "").trim());
+  if (!args.length) {
+    return null;
+  }
+
+  const [program, ...rest] = args;
+  const stdout = execFileSync(program, rest, {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+
+  const parsed = JSON.parse(stdout);
+
+  if (!parsed.AccessKeyId || !parsed.SecretAccessKey) {
+    throw new Error("credential_process output missing AccessKeyId/SecretAccessKey.");
+  }
+
+  return {
+    accessKeyId: parsed.AccessKeyId,
+    region: null,
+    secretAccessKey: parsed.SecretAccessKey,
+    sessionToken: parsed.SessionToken || null,
+    source: "credential_process"
+  };
+}
+
+function resolveStaticCredentialsFromProfile(profileName) {
+  const home = os.homedir();
+  const credsPath = process.env.AWS_SHARED_CREDENTIALS_FILE || path.join(home, ".aws", "credentials");
+  const configPath = process.env.AWS_CONFIG_FILE || path.join(home, ".aws", "config");
+
+  const credsSections = parseIniFile(credsPath);
+  const configSections = parseIniFile(configPath);
+
+  const credsEntry = resolveProfileSection(credsSections, profileName, "credentials") || {};
+  const configEntry = resolveProfileSection(configSections, profileName, "config") || {};
+
+  const accessKeyId = credsEntry.aws_access_key_id || configEntry.aws_access_key_id;
+  const secretAccessKey = credsEntry.aws_secret_access_key || configEntry.aws_secret_access_key;
+  const sessionToken = credsEntry.aws_session_token || configEntry.aws_session_token;
+  const region = configEntry.region || credsEntry.region;
+
+  if (accessKeyId && secretAccessKey) {
+    return {
+      accessKeyId,
+      region: region || null,
+      secretAccessKey,
+      sessionToken: sessionToken || null,
+      source: "shared-ini"
+    };
+  }
+
+  const credentialProcess = credsEntry.credential_process || configEntry.credential_process;
+  if (credentialProcess) {
+    const resolved = resolveCredentialProcess(credentialProcess);
+    if (resolved) {
+      return { ...resolved, region: region || null };
+    }
+  }
+
+  return null;
+}
+
+export async function resolveBedrockCredentials(profileName) {
+  if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
+    return {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      region: process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || null,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      sessionToken: process.env.AWS_SESSION_TOKEN || null,
+      source: "env"
+    };
+  }
+
+  const profile = profileName || process.env.AWS_PROFILE || "default";
+  const credentials = resolveStaticCredentialsFromProfile(profile);
+
+  if (!credentials) {
+    throw new Error(
+      `Unable to load AWS credentials for profile "${profile}". ` +
+        "Set SPACE_BEDROCK_API_KEY, AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, or populate ~/.aws/credentials."
+    );
+  }
+
+  return credentials;
+}
+
+function canonicalHeaders(headers) {
+  const lowered = Object.entries(headers)
+    .map(([name, value]) => [name.toLowerCase(), String(value).trim().replace(/\s+/gu, " ")])
+    .sort((left, right) => (left[0] < right[0] ? -1 : left[0] > right[0] ? 1 : 0));
+
+  const canonical = lowered.map(([name, value]) => `${name}:${value}\n`).join("");
+  const signed = lowered.map(([name]) => name).join(";");
+
+  return { canonical, signed };
+}
+
+function canonicalQueryString(url) {
+  const params = [];
+  url.searchParams.forEach((value, key) => {
+    params.push([encodeURIComponent(key), encodeURIComponent(value)]);
+  });
+  params.sort((left, right) => (left[0] < right[0] ? -1 : left[0] > right[0] ? 1 : 0));
+  return params.map(([key, value]) => `${key}=${value}`).join("&");
+}
+
+export function signBedrockRequest({ body, credentials, headers, method, region, url }) {
+  const now = new Date();
+  const amzDate = now
+    .toISOString()
+    .replace(/[:-]|\.\d{3}/gu, "")
+    .slice(0, 15) + "Z";
+  const dateStamp = amzDate.slice(0, 8);
+  const parsed = url instanceof URL ? url : new URL(url);
+  const bodyBuffer = body instanceof Buffer ? body : Buffer.from(body ?? "", "utf8");
+  const payloadHash = sha256Hex(bodyBuffer);
+
+  const workingHeaders = { ...headers };
+  workingHeaders.host = parsed.host;
+  workingHeaders["x-amz-date"] = amzDate;
+  workingHeaders["x-amz-content-sha256"] = payloadHash;
+
+  if (credentials.sessionToken) {
+    workingHeaders["x-amz-security-token"] = credentials.sessionToken;
+  }
+
+  const { canonical, signed } = canonicalHeaders(workingHeaders);
+  const canonicalRequest = [
+    method.toUpperCase(),
+    parsed.pathname || "/",
+    canonicalQueryString(parsed),
+    canonical,
+    signed,
+    payloadHash
+  ].join("\n");
+
+  const credentialScope = `${dateStamp}/${region}/${SERVICE}/aws4_request`;
+  const stringToSign = ["AWS4-HMAC-SHA256", amzDate, credentialScope, sha256Hex(canonicalRequest)].join("\n");
+
+  const kDate = hmac(`AWS4${credentials.secretAccessKey}`, dateStamp);
+  const kRegion = hmac(kDate, region);
+  const kService = hmac(kRegion, SERVICE);
+  const kSigning = hmac(kService, "aws4_request");
+  const signature = crypto.createHmac("sha256", kSigning).update(stringToSign, "utf8").digest("hex");
+
+  workingHeaders.authorization = `AWS4-HMAC-SHA256 Credential=${credentials.accessKeyId}/${credentialScope}, SignedHeaders=${signed}, Signature=${signature}`;
+
+  return { body: bodyBuffer, headers: workingHeaders };
+}

--- a/server/router/router.js
+++ b/server/router/router.js
@@ -8,6 +8,7 @@ import {
 } from "./request_context.js";
 import { handlePageRequest } from "./pages_handler.js";
 import { proxyExternalRequest } from "./proxy.js";
+import { handleBedrockRequest } from "../lib/bedrock/proxy.js";
 import { sendApiResult, sendJson } from "./responses.js";
 import { applyApiCorsHeaders, handleApiPreflight } from "./cors.js";
 import { handleModuleRequest } from "./mod_handler.js";
@@ -331,6 +332,15 @@ function createRequestHandler(options) {
         }
 
         await proxyExternalRequest(req, res, requestUrl);
+        return;
+      }
+
+      if (requestUrl.pathname === "/api/bedrock" || requestUrl.pathname.startsWith("/api/bedrock/")) {
+        if (!ensureAuthenticatedOrRespond(res, requestContext, auth)) {
+          return;
+        }
+
+        await handleBedrockRequest(req, res, requestUrl);
         return;
       }
 


### PR DESCRIPTION
## Summary

Adds **Amazon Bedrock** as a first-class LLM provider in the settings UI, alongside the existing generic **API** and **Local** options. Works with Claude on Bedrock (via the Converse API) and the OpenAI open-weights models hosted on Bedrock (via the native `/openai/v1/` route). The existing browser streaming reader is unchanged — the server re-emits OpenAI-shaped JSON / SSE for both routes.

Zero new runtime dependencies (pure Node built-ins). No existing code path or default behavior changes.

---

## UX changes

A new **Bedrock** tab appears in both settings dialogs (the admin view and the dashboard's "Set LLM API key" pill open the same tab).

**Bedrock tab contents**

- **Server credentials** — live-populated from `GET /api/bedrock/config`. Bulleted summary of the server's current auth mode (AWS profile SigV4 vs. Bedrock API key), profile name, region, and which env vars are driving it.
- **Credential mode** — radio:
  - *Use server credentials* → Node signs with the configured AWS profile (SigV4) or server-side Bedrock key. Works for Claude and gpt-oss.
  - *Paste a Bedrock API key* → key forwarded as `Authorization: Bearer`. Works for the OpenAI-compatible route only (Anthropic Bedrock requires SigV4).
- **Model** — dropdown with six sensible presets: Claude Sonnet 4.6, Opus 4.7, Opus 4.6, Haiku 4.5, OpenAI gpt-oss-20b, gpt-oss-120b.
- **Endpoint** is auto-chosen from model family — `openai.*` → `/api/bedrock/openai/v1/chat/completions`, everything else → `/api/bedrock/converse/v1/chat/completions`. The user never types a URL.

The API and Local tabs are untouched. Default provider is still API. No existing user's settings are migrated.

**House-style note:** the new `app/L0/_all/mod/_core/llm_settings/panel.html` follows the existing `huggingface/config-sidebar.html` pattern — a single `<x-component>` with a `mode="admin|onscreen"` attribute — so the admin and onscreen dialogs render identical UX from one file.

---

## Server — `/api/bedrock/**`

Three endpoints, all auth-gated via the same `ensureAuthenticatedOrRespond` as `/api/proxy`:

| Method | Path | Behavior |
|---|---|---|
| GET | `/api/bedrock/config` | Returns `{ mode: "sigv4" \| "apikey", profile, region, hasApiKey }` |
| POST | `/api/bedrock/openai/v1/chat/completions` | Signed pass-through to Bedrock's native OpenAI route. Honors a client-side `Authorization: Bearer` header so the *Paste a Bedrock API key* UI mode round-trips the key. Falls back to SigV4 with the configured AWS profile otherwise. |
| POST | `/api/bedrock/converse/v1/chat/completions` | OpenAI-chat → Bedrock Converse adapter. Translates `messages` / `system` / `inferenceConfig`, calls `/converse` or `/converse-stream`, emits a single OpenAI `chat.completion` (non-stream) or a stream of `chat.completion.chunk` frames + `data: [DONE]`. |

**Env-driven config; no new config files.**

| Variable | Purpose |
|---|---|
| `SPACE_BEDROCK_MODE` | `apikey` or `sigv4`; auto-detected if unset |
| `SPACE_BEDROCK_REGION` | Bedrock region; falls back to `AWS_REGION` |
| `SPACE_BEDROCK_API_KEY` | Long-term Bedrock API key (apikey mode) |
| `SPACE_BEDROCK_AWS_PROFILE` | AWS profile for SigV4; falls back to `AWS_PROFILE` |

Standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` env vars also work. AWS profiles using `credential_process` are supported natively.

---

## Why the Converse adapter

Anthropic models on Bedrock do **not** respond to the OpenAI-compatible `/openai/v1/` route — they expose the Converse API at `/model/{id}/converse[-stream]`. The adapter is what makes the existing browser client talk to Claude on Bedrock with no client-side changes.

Two behavioral notes baked into the adapter:

- Claude 4.5+ models deprecate `temperature` and `top_p` on Converse; the adapter strips both so requests don't 400 out. Older Claude models still get them.
- The streaming path decodes Bedrock's binary `application/vnd.amazon.eventstream` framing on the server (new `server/lib/bedrock/eventstream.js`) and re-emits plain `text/event-stream` chunks so the existing browser SSE reader works unchanged.

---

## Files changed (17 total, +1461 / −105)

**New Bedrock server code (5 files, +892 lines)**
- `server/lib/bedrock/sigv4.js` (+242) — SigV4 signer with env / shared-ini / `credential_process` credential resolution.
- `server/lib/bedrock/proxy.js` (+164) — request router for `/api/bedrock/**`.
- `server/lib/bedrock/converse.js` (+371) — OpenAI ↔ Converse adapter.
- `server/lib/bedrock/eventstream.js` (+115) — AWS eventstream binary decoder.
- `server/router/router.js` (+10) — wires the auth gate.

**New shared UI component (1 file, +157 lines)**
- `app/L0/_all/mod/_core/llm_settings/panel.html` (+157) — single settings component used by both dialogs via `mode="…"` attribute.

**Admin agent wiring (4 files)**
- `admin/views/agent/config.js` (+80) — enum, presets, route resolver.
- `admin/views/agent/store.js` (+98) — getters, actions, save-time projection.
- `admin/views/agent/storage.js` (+16/−5) — `allowMissing` opt-in.
- `admin/views/agent/panel.html` (+9/−29) — replaced inline block with `<x-component>`.

**Onscreen agent wiring (4 files)**
- `onscreen_agent/config.js`, `store.js`, `storage.js`, `panel.html` — parallel changes to the above.

**`allowMissing` plumbing (3 files)**
- `server/api/file_read.js` (+49/−6) — honors `allowMissing`; returns 200 `{exists:false}` on missing.
- `app/L0/_all/mod/_core/framework/js/api-client.js` (+22) — threads flag through request builders and bypasses the queue batcher when set.
- `dashboard_welcome/dashboard-prefs.js` (+5/−1) — opts in.

See the commit message for the per-file breakdown.

---

## Side fix: `/api/file_read` 404 noise (opt-in)

First-run dashboard / agent loads trigger `/api/file_read` 404s for `~/conf/dashboard.yaml` and `~/hist/{admin-chat,onscreen-agent}.json` that don't yet exist. The calling code already handles the missing case; only DevTools noise remains.

This PR adds an opt-in `allowMissing: true` flag on the object form of `runtime.api.fileRead(…)` and `runtime.api.fileDelete(…)`. When set and the path is missing, the server returns `200 { exists: false, content: "" }` instead of 404. When unset, behavior is identical to before.

Shares the plumbing with the new `GET /api/bedrock/config`. **Happy to split into a separate PR if you prefer** — let me know.

---

## Backward compatibility

- Provider defaults unchanged (API). The new `BEDROCK` enum value has no effect unless the user selects it.
- No existing config files are read, written, renamed, or migrated.
- No existing public API changed. `createFileReadRequest` / `createFileDeleteRequest` and the file-op callers are additive.
- Server boots without any `SPACE_BEDROCK_*` env vars set; `/api/bedrock/**` is simply unavailable in that case, and every other path behaves as before.
- **Zero new runtime dependencies.** Pure Node built-ins (`crypto`, `child_process`, `stream`, global `fetch`).

---

## Live test evidence

All calls against `bedrock-runtime.us-west-2.amazonaws.com`:

| Route | Model | Stream | Result |
|---|---|:---:|---|
| `/api/bedrock/openai/v1/chat/completions` | `openai.gpt-oss-20b-1:0` | no | 200, usage returned |
| `/api/bedrock/converse/v1/chat/completions` | `us.anthropic.claude-sonnet-4-6` | no | 200, `"pong"` |
| `/api/bedrock/converse/v1/chat/completions` | `us.anthropic.claude-opus-4-6-v1` | no | 200, `"pong"` |
| `/api/bedrock/converse/v1/chat/completions` | `us.anthropic.claude-opus-4-7` | no | 200, `"pong"` |
| `/api/bedrock/converse/v1/chat/completions` | `us.anthropic.claude-sonnet-4-6` | yes | 4 SSE chunks + `data: [DONE]`, `finish_reason: "stop"` |
| `/api/bedrock/converse/v1/chat/completions` | `us.anthropic.claude-opus-4-7` + `temperature: 0.2` | no | 200 (adapter strips deprecated temp; previously 400) |
| `/api/file_read` `{path:"~/conf/dashboard.yaml", allowMissing:true}` | — | — | 200 `{exists:false, content:""}` (previously 404) |
| Server boot with no `SPACE_BEDROCK_*` env vars set | — | — | boots; existing API / Local tabs unaffected |

What I did **not** verify:
- Windows / Linux desktop Electron builds. I only tested via `node space serve` + browser on macOS.
- Tool-calls and image parts through Converse (adapter is text-only for now — see non-goals).

---

## Non-goals / known limitations

- **Converse adapter is text-only.** Tool calls, image parts, and documents aren't translated yet. Happy to follow up in a separate PR.
- **Bedrock's `/openai/v1/` route only serves OpenAI open-weights models** on Bedrock (`gpt-oss-20b`, `gpt-oss-120b`). That's an AWS-side limitation, not a client bug — hence the route split.
- **Model presets are hand-curated.** A maintainer-preferred way to resolve available models dynamically (e.g. `list-inference-profiles`) would be a nice follow-up; any ID can still be typed.

---

## How to try it

```bash
AWS_PROFILE=<your-profile> \
SPACE_BEDROCK_MODE=sigv4 \
SPACE_BEDROCK_REGION=us-west-2 \
  node space serve SINGLE_USER_APP=true
```

Open `http://127.0.0.1:3000`, open the agent settings, pick the **Bedrock** tab, choose a Claude model, save, chat.
