### PR TITLE
fix(widgets): reject unknown patch edit fields, list accepted aliases

### DIFF
--- a/app/L0/_all/mod/_core/spaces/ext/skills/space-widgets/SKILL.md
+++ b/app/L0/_all/mod/_core/spaces/ext/skills/space-widgets/SKILL.md
@@ -139,7 +139,9 @@ patch vs rewrite
 - from and to are inclusive zero-based renderer line numbers
 - Omit to to insert before from
 - Omit content on a ranged line edit to delete
-- Common line aliases like line, startLine/endLine, range, text, and replace are tolerated, but prefer the canonical shapes above
+- Common coordinate aliases like line, startLine/endLine, and range are tolerated, but prefer the canonical shapes above
+- Common content aliases like text, replace, value, replaceWith, replacement, and newText are tolerated, but prefer canonical content
+- Other field names on an edit object are rejected fast with a list of accepted aliases. Do not invent fields like path, replaceText, or body — they are unrecognized and the edit will be refused before any line is touched
 - Do not mix exact find edits and line edits in the same call
 - Do not overlap edits
 - The runtime applies edits from higher line numbers down to lower ones

--- a/app/L0/_all/mod/_core/spaces/storage.js
+++ b/app/L0/_all/mod/_core/spaces/storage.js
@@ -618,33 +618,60 @@ function isWidgetPatchTextLike(value) {
   return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
 }
 
+// Field names accepted as replacement-text aliases on a widget patch edit.
+// `content` is canonical; `text`, `replace`, `value`, `replaceWith`,
+// `replacement`, and `newText` are tolerated because LLM patch outputs
+// frequently default to those names from VS Code, OpenAI tool-call,
+// jsondiffpatch, and similar conventions. Listing them explicitly here
+// also lets the validator surface a precise error message when none of the
+// aliases is set on a `replace`-style line edit.
+const WIDGET_PATCH_CONTENT_FIELD_ALIASES = Object.freeze([
+  "content",
+  "text",
+  "replace",
+  "value",
+  "replaceWith",
+  "replacement",
+  "newText"
+]);
+
+// All field names the widget patch validator recognizes on an edit object.
+// Anything outside this set is unknown and almost certainly a typo'd content
+// alias from an LLM (`with`, `replaceText`, `body`, `newContent`, ...). The
+// validator surfaces unknown fields as an explicit error so the agent does
+// not silently delete renderer lines when its replacement text is rejected
+// by name mismatch.
+const WIDGET_PATCH_KNOWN_EDIT_FIELDS = Object.freeze([
+  ...WIDGET_PATCH_CONTENT_FIELD_ALIASES,
+  "find",
+  "search",
+  "from",
+  "to",
+  "line",
+  "startLine",
+  "endLine",
+  "range",
+  "mode",
+  "kind"
+]);
+
+function listUnknownWidgetPatchEditFields(edit = {}) {
+  if (!edit || typeof edit !== "object" || Array.isArray(edit)) {
+    return [];
+  }
+
+  const knownFieldSet = new Set(WIDGET_PATCH_KNOWN_EDIT_FIELDS);
+  return Object.keys(edit).filter((key) => !knownFieldSet.has(key));
+}
+
 function readWidgetPatchContentField(edit = {}) {
-  if (hasOwnWidgetPatchField(edit, "content")) {
-    return {
-      key: "content",
-      value: edit.content
-    };
-  }
-
-  if (hasOwnWidgetPatchField(edit, "text")) {
-    return {
-      key: "text",
-      value: edit.text
-    };
-  }
-
-  if (hasOwnWidgetPatchField(edit, "replace")) {
-    return {
-      key: "replace",
-      value: edit.replace
-    };
-  }
-
-  if (hasOwnWidgetPatchField(edit, "value")) {
-    return {
-      key: "value",
-      value: edit.value
-    };
+  for (const aliasKey of WIDGET_PATCH_CONTENT_FIELD_ALIASES) {
+    if (hasOwnWidgetPatchField(edit, aliasKey)) {
+      return {
+        key: aliasKey,
+        value: edit[aliasKey]
+      };
+    }
   }
 
   return null;
@@ -732,6 +759,16 @@ function normalizeWidgetTextPatchEdit(edit, sourceText) {
 function normalizeWidgetPatchEdit(edit, lineCount, sourceText) {
   const normalizedEdit = edit && typeof edit === "object" ? edit : {};
 
+  const unknownFields = listUnknownWidgetPatchEditFields(normalizedEdit);
+  if (unknownFields.length > 0) {
+    throw new Error(
+      `Widget patch edit has unknown field${unknownFields.length === 1 ? "" : "s"} ${unknownFields.map((name) => `\`${name}\``).join(", ")}. ` +
+        `Valid replacement-text fields are ${WIDGET_PATCH_CONTENT_FIELD_ALIASES.map((name) => `\`${name}\``).join(", ")}; ` +
+        `valid coordinates are \`from\`/\`to\` (canonical) or \`line\`/\`startLine\`/\`endLine\`/\`range\` aliases; ` +
+        `exact-snippet edits use \`find\` (or \`search\`) plus a replacement field.`
+    );
+  }
+
   if (hasOwnWidgetPatchField(normalizedEdit, "find") || hasOwnWidgetPatchField(normalizedEdit, "search")) {
     return normalizeWidgetTextPatchEdit(normalizedEdit, sourceText);
   }
@@ -765,7 +802,9 @@ function normalizeWidgetPatchEdit(edit, lineCount, sourceText) {
   }
 
   if (!hasTo && !hasContent) {
-    throw new Error("Insert edits must include replacement text in `content`.");
+    throw new Error(
+      `Insert edits must include replacement text. Use \`content\` (canonical) or one of: ${WIDGET_PATCH_CONTENT_FIELD_ALIASES.slice(1).map((name) => `\`${name}\``).join(", ")}.`
+    );
   }
 
   if (!hasTo) {


### PR DESCRIPTION
# fix(widgets): reject unknown fields and document accepted aliases on patchWidget edits

## Summary

`spaces/storage.js` accepts widget patch edits with unrecognized field names (e.g. `replaceWith`, `path`, `with`) without surfacing an error and silently produces a no-op or destructive patch. This PR adds an unknown-field validator and lists the accepted replacement-text aliases in the existing error messages so a misnamed edit fails fast with a precise hint instead of corrupting the renderer.

## Why

LLM patch outputs frequently default to field names from VS Code edit APIs, OpenAI tool-call schemas, jsondiffpatch, etc. — for example `replaceWith` instead of the canonical `content`/`replace`/`text`/`value` aliases the widget patch validator currently accepts. Today the validator silently drops unrecognized fields, producing two failure modes I reproduced repeatedly during local widget development:

**Failure mode A — silent line deletion.** An edit like

```js
patchWidget("embedded-browser", {
  edits: [
    { path: "renderer", line: 264, replaceWith: "..." },
    { path: "renderer", line: 265, replaceWith: "..." }
  ]
})
```

is accepted by the validator. `line` is treated as alias for both `from` and `to` so each edit becomes a single-line replace at line 264, 265, etc. None of the `replaceWith` payloads is read because `replaceWith` is not in the recognized aliases set. The replace path falls through to `contentLines: hasContent ? ... : []`, treating the missing replacement as an explicit "delete this line" intent. Six replacement edits become six silent line deletions, the runtime reports `Widget "X" saved, rendered ok, loaded to TRANSIENT`, and the agent receives a positive result for what was actually a destructive change.

**Failure mode B — uninformative error.** When a more obviously broken edit does fail (e.g. an insert without any replacement field), the existing message — `"Insert edits must include replacement text in \`content\`."` — does not list the other accepted aliases, so the agent often retries with another non-canonical name (`with`, `body`, `newContent`, ...) and still fails.

The widget-skill SKILL.md already pins the canonical shapes and explicitly notes that `line`, `startLine`/`endLine`, `range`, `text`, and `replace` are tolerated aliases. The validator did not carry that contract through to the actual checks.

## What changed

Single-file change in `app/L0/_all/mod/_core/spaces/storage.js`:

1. **`WIDGET_PATCH_CONTENT_FIELD_ALIASES` constant** lists the recognized replacement-text aliases: `content` (canonical), `text`, `replace`, `value`, plus newly added `replaceWith`, `replacement`, `newText`. The existing `readWidgetPatchContentField(...)` is rewritten to iterate this list rather than hard-code a four-branch ladder. No behavior change for existing callers; the three new aliases unblock common LLM patch shapes that previously had to be hand-corrected.

2. **`WIDGET_PATCH_KNOWN_EDIT_FIELDS` constant** captures the full set of edit-object fields the validator recognizes: every content alias plus `find`, `search`, `from`, `to`, `line`, `startLine`, `endLine`, `range`, `mode`, `kind`. New `listUnknownWidgetPatchEditFields(...)` helper returns any keys outside that set.

3. **`normalizeWidgetPatchEdit(...)` rejects unknown fields** at the top of the function, before any other validation. The error message lists the accepted replacement-text aliases, the accepted coordinate aliases, and the `find`/`search` snippet shape so the agent can self-correct on the next turn. This closes the silent-deletion path because a typo'd content field name now fails with a clear name rather than being interpreted as an absent replacement.

4. **Existing insert-error message** is widened to list all accepted replacement-text aliases instead of only `content`, matching the rest of the validator's diagnostic style.

5. **`space-widgets/SKILL.md` updated to match the validator's new strict-mode contract.** The "patch vs rewrite" subsection now distinguishes coordinate aliases from content aliases, lists `replaceWith`/`replacement`/`newText` alongside the previously documented content fields, and explicitly states that other field names will be rejected fast. `path`, `replaceText`, and `body` are called out as common typo'd field names so the agent does not generate them.

No API change, no test touched (the patch validator is not exercised by unit tests in this repo today; adding one would require either exporting `applyWidgetPatchEdits` or providing a module resolver for the `/mod/...` absolute imports that `spaces/storage.js` uses, both of which are outside this PR's scope).

## Worked example — silent deletion case

Before:

```js
edits: [{ path: "renderer", line: 264, replaceWith: "x" }]
// path: ignored, line: from=to=264, replaceWith: not an alias → no content
// validator returns { kind: "replace", from: 264, to: 264, contentLines: [] }
// → silently deletes line 264, runtime says "saved, rendered ok"
```

After:

```
Error: Widget patch edit has unknown field `path`. Valid replacement-text
fields are `content`, `text`, `replace`, `value`, `replaceWith`,
`replacement`, `newText`; valid coordinates are `from`/`to` (canonical) or
`line`/`startLine`/`endLine`/`range` aliases; exact-snippet edits use
`find` (or `search`) plus a replacement field.
```

The agent receives the diagnostic, drops `path`, replaces `replaceWith` with `content` if it must, and retries.

## Test plan

- [x] `node --check app/L0/_all/mod/_core/spaces/storage.js` passes
- [x] Existing `tests/spaces_widget_import_test.mjs` and `tests/spaces_prompt_context_test.mjs` continue to pass (validator is not exercised but the file imports cleanly)
- [x] Manual unknown-field detection table verified: `{find,replace}`, `{from,to,content}`, `{line,replace}`, `{range,text}` all return zero unknowns; `{path,line,replaceWith}` flags `path`; `{from,to,with}` flags `with`; `{line,replaceWith}` returns zero unknowns (i.e. now passes through as expected)
- [x] Manual verification across two providers in `npm run desktop:pack` builds:
  - **gpt-5.4 via OpenAI Codex provider** — captured the failure mode reliably (LLM-generated patch with `path: "renderer", line: N, replaceWith: ...` shape) and confirmed it now fails fast with the new error message; the agent self-corrects to `find/replaceWith` on the next turn and the patch then applies as intended
  - **Local qwen3-coder model** — produces canonical `find/replace` shapes that already passed the validator pre-PR, and continues to pass post-PR. No regression for well-formed edits

## Out of scope (possible follow-ups)

- A `delete: true` marker on line edits to disambiguate "intentional delete" from "missing content field," replacing the implicit `content`-omitted convention. The current PR keeps the implicit convention to avoid touching the SKILL contract.
- Symmetric unknown-field detection on the metadata-side patch fields (`name`, `cols`, `rows`, etc.) handled by the surrounding `patchWidget` body. Those are a separate code path and outside the line-edit validator changed here.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
