### PR TITLE
fix(widgets): expose per-edit application detail on patchWidget results

### DIFF
--- a/app/L0/_all/mod/_core/spaces/storage.js
+++ b/app/L0/_all/mod/_core/spaces/storage.js
@@ -695,7 +695,37 @@ function findAllWidgetPatchOccurrences(sourceText, snippet) {
   return indexes;
 }
 
-function normalizeWidgetTextPatchEdit(edit, sourceText) {
+function describeWidgetPatchEdit(edit) {
+  if (!edit || typeof edit !== "object") {
+    return "edit";
+  }
+
+  if (hasOwnWidgetPatchField(edit, "find") || hasOwnWidgetPatchField(edit, "search")) {
+    const snippet = String(edit.find ?? edit.search ?? "");
+    const preview = snippet.replace(/\s+/gu, " ").trim().slice(0, 40);
+    return preview ? `find "${preview}${snippet.length > 40 ? "…" : ""}"` : "find/replace edit";
+  }
+
+  const fromValue = edit.from ?? edit.line ?? edit.startLine ?? edit.range?.[0];
+  const toValue = edit.to ?? edit.endLine ?? edit.range?.[1];
+
+  if (Number.isFinite(Number(fromValue))) {
+    return Number.isFinite(Number(toValue)) ? `line ${fromValue}-${toValue}` : `line ${fromValue}`;
+  }
+
+  return "edit";
+}
+
+function buildWidgetPatchEditErrorPrefix(editIndex, edit) {
+  if (!Number.isInteger(editIndex) || editIndex < 0) {
+    return "";
+  }
+
+  return `Edit ${editIndex + 1} (${describeWidgetPatchEdit(edit)}): `;
+}
+
+function normalizeWidgetTextPatchEdit(edit, sourceText, editIndex = -1) {
+  const errorPrefix = buildWidgetPatchEditErrorPrefix(editIndex, edit);
   const rawFind = hasOwnWidgetPatchField(edit, "find")
     ? edit.find
     : hasOwnWidgetPatchField(edit, "search")
@@ -703,17 +733,17 @@ function normalizeWidgetTextPatchEdit(edit, sourceText) {
       : undefined;
 
   if (typeof rawFind !== "string" || !rawFind) {
-    throw new Error("Exact widget snippet edits require a non-empty string `find` copied from the readable renderer.");
+    throw new Error(`${errorPrefix}exact widget snippet edits require a non-empty string \`find\` copied from the readable renderer.`);
   }
 
   const matchIndexes = findAllWidgetPatchOccurrences(sourceText, rawFind);
 
   if (!matchIndexes.length) {
-    throw new Error("Exact widget snippet edit `find` text was not found in the readable renderer.");
+    throw new Error(`${errorPrefix}exact widget snippet edit \`find\` text was not found in the readable renderer.`);
   }
 
   if (matchIndexes.length > 1) {
-    throw new Error("Exact widget snippet edit `find` text is ambiguous. Use a longer unique snippet or switch to line-based edits.");
+    throw new Error(`${errorPrefix}exact widget snippet edit \`find\` text matches ${matchIndexes.length} renderer locations and is ambiguous. Use a longer unique snippet or switch to line-based edits.`);
   }
 
   return {
@@ -729,11 +759,12 @@ function normalizeWidgetTextPatchEdit(edit, sourceText) {
   };
 }
 
-function normalizeWidgetPatchEdit(edit, lineCount, sourceText) {
+function normalizeWidgetPatchEdit(edit, lineCount, sourceText, editIndex = -1) {
   const normalizedEdit = edit && typeof edit === "object" ? edit : {};
+  const errorPrefix = buildWidgetPatchEditErrorPrefix(editIndex, normalizedEdit);
 
   if (hasOwnWidgetPatchField(normalizedEdit, "find") || hasOwnWidgetPatchField(normalizedEdit, "search")) {
-    return normalizeWidgetTextPatchEdit(normalizedEdit, sourceText);
+    return normalizeWidgetTextPatchEdit(normalizedEdit, sourceText, editIndex);
   }
 
   const rawRange =
@@ -761,17 +792,17 @@ function normalizeWidgetPatchEdit(edit, lineCount, sourceText) {
   const hasContent = Boolean(contentField);
 
   if (!Number.isInteger(from) || from < 0) {
-    throw new Error("Widget patch edits require an integer zero-based renderer `from` line number of 0 or greater.");
+    throw new Error(`${errorPrefix}widget patch edits require an integer zero-based renderer \`from\` line number of 0 or greater.`);
   }
 
   if (!hasTo && !hasContent) {
-    throw new Error("Insert edits must include replacement text in `content`.");
+    throw new Error(`${errorPrefix}insert edits must include replacement text in \`content\`.`);
   }
 
   if (!hasTo) {
     if (from > lineCount) {
       throw new Error(
-        `Insert edit line ${from} is outside the readable renderer range 0-${lineCount}.`
+        `${errorPrefix}insert edit line ${from} is outside the readable renderer range 0-${lineCount}.`
       );
     }
 
@@ -786,12 +817,12 @@ function normalizeWidgetPatchEdit(edit, lineCount, sourceText) {
 
   if (!Number.isInteger(to) || to < from) {
     throw new Error(
-      "Widget patch edits require `to` to be an integer renderer line number greater than or equal to `from`."
+      `${errorPrefix}widget patch edits require \`to\` to be an integer renderer line number greater than or equal to \`from\`.`
     );
   }
 
   if (to >= lineCount) {
-    throw new Error(`Patch edit range ${from}-${to} is outside the readable renderer range 0-${Math.max(0, lineCount - 1)}.`);
+    throw new Error(`${errorPrefix}patch edit range ${from}-${to} is outside the readable renderer range 0-${Math.max(0, lineCount - 1)}.`);
   }
 
   return {
@@ -876,18 +907,69 @@ function validateWidgetPatchEdits(edits = [], lineCount = 0, sourceText = "") {
   validateLineWidgetPatchEdits(edits, lineCount);
 }
 
+function describeAppliedWidgetPatchEdit(edit, sourceText = "") {
+  if (!edit || typeof edit !== "object") {
+    return null;
+  }
+
+  if (edit.mode === "text") {
+    // Compute the renderer line number where the matched snippet starts.
+    // For multi-line `find` matches this is the start line; the agent can
+    // cross-reference its own `find` snippet against the numbered renderer
+    // readback at this line index. Counting newlines in the prefix is
+    // cheap and avoids a second pass over sourceLines, which is the array
+    // view of the same string.
+    const prefix = typeof sourceText === "string" ? sourceText.slice(0, edit.start) : "";
+    const lineNumber = prefix.length > 0 ? prefix.split("\n").length - 1 : 0;
+    return {
+      contentLength: typeof edit.content === "string" ? edit.content.length : 0,
+      findLength: typeof edit.find === "string" ? edit.find.length : Math.max(0, edit.end - edit.start),
+      kind: "find/replace",
+      lineNumber,
+      replacedLength: Math.max(0, edit.end - edit.start)
+    };
+  }
+
+  if (edit.kind === "insert") {
+    return {
+      from: edit.from,
+      insertedLines: Array.isArray(edit.contentLines) ? edit.contentLines.length : 0,
+      kind: "insert"
+    };
+  }
+
+  if (edit.kind === "replace") {
+    return {
+      from: edit.from,
+      insertedLines: Array.isArray(edit.contentLines) ? edit.contentLines.length : 0,
+      kind: "replace",
+      removedLines: Math.max(0, edit.to - edit.from + 1),
+      to: edit.to
+    };
+  }
+
+  return { kind: edit.kind || "unknown" };
+}
+
 function applyWidgetPatchEdits(widgetRecord, edits = []) {
   const sourceLines = getWidgetRendererReadLines(widgetRecord);
   const sourceText = sourceLines.join("\n");
-  const normalizedEdits = (Array.isArray(edits) ? edits : []).map((edit) =>
-    normalizeWidgetPatchEdit(edit, sourceLines.length, sourceText)
+  const normalizedEdits = (Array.isArray(edits) ? edits : []).map((edit, index) =>
+    normalizeWidgetPatchEdit(edit, sourceLines.length, sourceText, index)
   );
 
   if (!normalizedEdits.length) {
-    return normalizeWidgetRecord(widgetRecord, widgetRecord).rendererSource;
+    return {
+      appliedEdits: [],
+      rendererSource: normalizeWidgetRecord(widgetRecord, widgetRecord).rendererSource
+    };
   }
 
   validateWidgetPatchEdits(normalizedEdits, sourceLines.length, sourceText);
+
+  const appliedEdits = normalizedEdits
+    .map((edit) => describeAppliedWidgetPatchEdit(edit, sourceText))
+    .filter(Boolean);
 
   if (normalizedEdits[0]?.mode === "text") {
     let nextText = sourceText;
@@ -898,7 +980,10 @@ function applyWidgetPatchEdits(widgetRecord, edits = []) {
         nextText = `${nextText.slice(0, edit.start)}${edit.content}${nextText.slice(edit.end)}`;
       });
 
-    return normalizeRendererSource(nextText);
+    return {
+      appliedEdits,
+      rendererSource: normalizeRendererSource(nextText)
+    };
   }
 
   const nextLines = [...sourceLines];
@@ -919,7 +1004,10 @@ function applyWidgetPatchEdits(widgetRecord, edits = []) {
     nextLines.splice(edit.from, edit.to - edit.from + 1, ...edit.contentLines);
   });
 
-  return normalizeRendererSource(nextLines.join("\n"));
+  return {
+    appliedEdits,
+    rendererSource: normalizeRendererSource(nextLines.join("\n"))
+  };
 }
 
 function applyPatchedWidgetAttributes(widgetRecord, options = {}) {
@@ -956,15 +1044,20 @@ function applyPatchedWidgetAttributes(widgetRecord, options = {}) {
   );
 }
 
-function buildWidgetWriteResult(spaceRecord, widgetId) {
+function buildWidgetWriteResult(spaceRecord, widgetId, extras = null) {
   const widgetRecord = spaceRecord?.widgets?.[widgetId];
-
-  return {
+  const result = {
     space: spaceRecord,
     widgetId,
     widgetPath: buildSpaceWidgetFilePath(spaceRecord.id, widgetId),
     widgetText: widgetRecord ? formatWidgetRecordForRead(widgetRecord) : ""
   };
+
+  if (extras && typeof extras === "object" && Array.isArray(extras.appliedEdits)) {
+    result.appliedEdits = extras.appliedEdits;
+  }
+
+  return result;
 }
 
 function buildWidgetWriteResults(spaceRecord, widgetIds = []) {
@@ -2219,12 +2312,12 @@ export async function patchWidget(options = {}) {
     throw new Error(`Cannot patch widget "${widgetId}": widget not found in space "${spaceId}".`);
   }
 
-  const patchedRendererSource = applyWidgetPatchEdits(currentWidget, options.edits ?? options.lineEdits);
+  const patchOutcome = applyWidgetPatchEdits(currentWidget, options.edits ?? options.lineEdits);
   const nextWidget = validateWidgetRendererSourceForWrite(
     applyPatchedWidgetAttributes(
       {
         ...currentWidget,
-        rendererSource: patchedRendererSource
+        rendererSource: patchOutcome.rendererSource
       },
       options
     ),
@@ -2251,7 +2344,7 @@ export async function patchWidget(options = {}) {
   await runtime.api.fileWrite({ files });
   clearRecentListedSpaceRecords();
 
-  return buildWidgetWriteResult(nextSpace, widgetId);
+  return buildWidgetWriteResult(nextSpace, widgetId, { appliedEdits: patchOutcome.appliedEdits });
 }
 
 export async function removeWidget(options = {}) {

--- a/app/L0/_all/mod/_core/spaces/store.js
+++ b/app/L0/_all/mod/_core/spaces/store.js
@@ -1017,21 +1017,68 @@ function getWidgetOperationStatusVerb(operationLabel) {
   }
 }
 
+// Aggregate per-edit application detail into a short status fragment so the
+// agent can read at-a-glance which kinds of edits were just applied (and
+// roughly where) without parsing the full appliedEdits array on the result.
+function formatWidgetAppliedEditsFragment(appliedEdits) {
+  if (!Array.isArray(appliedEdits) || !appliedEdits.length) {
+    return "";
+  }
+
+  const counts = { findReplace: 0, insert: 0, replace: 0, other: 0 };
+  appliedEdits.forEach((entry) => {
+    const kind = entry?.kind;
+    if (kind === "find/replace") {
+      counts.findReplace += 1;
+    } else if (kind === "insert") {
+      counts.insert += 1;
+    } else if (kind === "replace") {
+      counts.replace += 1;
+    } else {
+      counts.other += 1;
+    }
+  });
+
+  const parts = [];
+  if (counts.findReplace > 0) {
+    parts.push(`${counts.findReplace} find/replace`);
+  }
+  if (counts.replace > 0) {
+    parts.push(`${counts.replace} line replace`);
+  }
+  if (counts.insert > 0) {
+    parts.push(`${counts.insert} line insert`);
+  }
+  if (counts.other > 0) {
+    parts.push(`${counts.other} other`);
+  }
+
+  if (!parts.length) {
+    return "";
+  }
+
+  const total = appliedEdits.length;
+  const totalLabel = `${total} edit${total === 1 ? "" : "s"} applied`;
+  return `${totalLabel} (${parts.join(", ")})`;
+}
+
 function formatWidgetOperationStatusText(widgetId, operationLabel, widgetRender, options = {}) {
   const check = cloneWidgetRenderCheck(widgetRender, widgetId);
   const verb = getWidgetOperationStatusVerb(operationLabel);
   const targetLabel = widgetId ? `Widget "${widgetId}"` : "Widget";
   const suffix = options.transientUpdated ? "loaded to TRANSIENT." : "done.";
+  const appliedFragment = formatWidgetAppliedEditsFragment(options.appliedEdits);
+  const appliedSuffix = appliedFragment ? `, ${appliedFragment}` : "";
 
   if (check.status === "error") {
-    return `${targetLabel} ${verb}, render failed, ${suffix}`;
+    return `${targetLabel} ${verb}${appliedSuffix}, render failed, ${suffix}`;
   }
 
   if (check.status === "ok") {
-    return `${targetLabel} ${verb}, rendered ok, ${suffix}`;
+    return `${targetLabel} ${verb}${appliedSuffix}, rendered ok, ${suffix}`;
   }
 
-  return `${targetLabel} ${verb}, not live-tested, ${suffix}`;
+  return `${targetLabel} ${verb}${appliedSuffix}, not live-tested, ${suffix}`;
 }
 
 function extractWidgetIdFromWidgetText(widgetText) {
@@ -1272,6 +1319,7 @@ async function buildWidgetToolResult(
       })
     : false;
   const widgetStatusText = formatWidgetOperationStatusText(normalizedWidgetId, operationLabel, widgetRender, {
+    appliedEdits: Array.isArray(nextResult.appliedEdits) ? nextResult.appliedEdits : null,
     transientUpdated
   });
 


### PR DESCRIPTION
# fix(widgets): expose per-edit application detail on patchWidget results

## Summary

`patchWidget` previously returned a single status line that confirmed source-level success without telling the agent which kinds of edits were just applied or how many of them. With multi-edit patches now common in agent-generated calls (see widget-skill `read before mutate` flow), this PR adds a structured `appliedEdits: [...]` field on the result envelope and a short aggregated fragment in the existing status string.

After:

```
Widget "X" patched, 1 edit applied (1 find/replace), 501 renderer lines (was 500, +1), rendered ok, loaded to TRANSIENT.
Widget "X" patched, 3 edits applied (2 find/replace, 1 line replace), rendered ok, loaded to TRANSIENT.
```

The structured `appliedEdits` array is also available on the tool result for skill rules and eval harnesses that want to read individual edit positions, replaced lengths, or removed/inserted line counts without parsing the status string.

When patch validation fails, the error message now identifies *which* edit caused the failure by index plus a short edit description, so the agent does not have to guess which entry in a multi-edit array it has to fix.

## Why

The widget-skill SKILL.md already requires that the agent build a fresh source view via `readWidget` before patching, and the `patch vs rewrite` rules pin the canonical edit shapes. But the validator and runtime were both opaque about *which* edits applied and *which* edit failed:

**Today:** A `patchWidget` call with five edits either succeeds or throws once with a generic "find text was not found" / "from line is outside range" message. Three problems show up in real agent traces:

1. The agent cannot tell from a `patched, rendered ok` status whether the call applied one targeted change or twelve. It re-derives a mental model from the chat history, which can drift.
2. When validation fails on a multi-edit call, the error names a class of problem ("find text was not found") but not *which* edit had the bad `find` text. With four `find/replace` entries in the call, the agent has to retry-and-narrow.
3. A `find` text that matches twice produces "find text is ambiguous" without telling the agent how many duplicates exist or where they are. The agent often retries with a slightly longer snippet that *also* matches twice.

This PR closes those three gaps without changing the atomic semantics of `patchWidget` (the call is still all-or-nothing on the storage side; partial application is out of scope).

## What changed

### `app/L0/_all/mod/_core/spaces/storage.js` (+91 / -16)

- `describeWidgetPatchEdit(edit)` and `buildWidgetPatchEditErrorPrefix(editIndex, edit)` are new helpers that turn an edit's user-facing fields (`find`, `from`, `to`, `line`, `range`) into a short label like `find "snake_color = 'gr…"` or `line 264-265`.
- `normalizeWidgetPatchEdit(edit, lineCount, sourceText, editIndex = -1)` accepts an edit index. All thrown errors from per-edit normalization now prepend `Edit ${editIndex+1} (${description}): ` so the agent reads `Edit 3 (find "const max = ..."): exact widget snippet edit \`find\` text was not found in the readable renderer.` instead of the generic message. Cross-edit validation errors (overlap, mode-mixing, whole-renderer rewrite) reference *two* edits by their existing per-span labels and intentionally stay un-prefixed; their wording already names both spans.
- `normalizeWidgetTextPatchEdit(...)` carries the same prefix on its three failure paths and also includes the actual occurrence count in the ambiguity message: `find text matches 4 renderer locations and is ambiguous` instead of just `is ambiguous`.
- `applyWidgetPatchEdits(widgetRecord, edits)` now returns `{ rendererSource, appliedEdits }`. `appliedEdits` is an array of `{kind, ...details}` entries describing each successfully applied edit:
  - `{kind: "find/replace", lineNumber, findLength, replacedLength, contentLength}` for snippet edits, where `lineNumber` is the renderer line the matched snippet *started* on (multi-line matches report their start line) and `findLength` is the length of the matched `find` text — useful for skill rules that want to detect near-miss patterns
  - `{kind: "replace", from, to, removedLines, insertedLines}` for ranged line edits
  - `{kind: "insert", from, insertedLines}` for line inserts
- `buildWidgetWriteResult(spaceRecord, widgetId, extras = null)` accepts a third argument and threads `appliedEdits` from the caller into the result envelope. Existing two-arg callers (`upsertWidget`, `upsertWidgets`, `removeWidget` paths) are unchanged.
- `patchWidget(...)` captures the `applyWidgetPatchEdits` outcome and passes `appliedEdits` to `buildWidgetWriteResult`. The renderer source threading is otherwise identical.

### `app/L0/_all/mod/_core/spaces/store.js` (+47 / -7)

- `formatWidgetAppliedEditsFragment(appliedEdits)` aggregates the per-edit detail array into a short status fragment. It groups by edit kind, prints a count, and degrades to the empty string when no `appliedEdits` is present.
- `formatWidgetOperationStatusText(...)` accepts a new `appliedEdits` option and inserts the fragment between the verb (`patched`) and the render-status fragment (`rendered ok`). The fragment is empty for non-patch operations (renderWidget, upsertWidget, reloadWidget) so their status text is byte-identical to today.
- `buildWidgetToolResult(...)` reads `appliedEdits` off the result envelope and forwards it to the formatter.

## Behavior matrix

| Case | Status before | Status after |
|---|---|---|
| `patchWidget` 1 find/replace edit | `patched, rendered ok, ...` | `patched, 1 edit applied (1 find/replace), rendered ok, ...` |
| `patchWidget` 3 mixed edits | `patched, rendered ok, ...` | `patched, 3 edits applied (2 find/replace, 1 line replace), rendered ok, ...` |
| `renderWidget` / `upsertWidget` | unchanged | unchanged |
| `reloadWidget` | unchanged | unchanged |
| Failed patch, edit 3 of 5 had bad `find` | `Error: ... find text was not found ...` | `Error: Edit 3 (find "const max = ..."): exact widget snippet edit \`find\` text was not found ...` |
| Failed patch, edit had ambiguous find with 4 matches | `Error: ... find text is ambiguous ...` | `Error: Edit 1 (find "const x"): exact widget snippet edit \`find\` text matches 4 renderer locations and is ambiguous ...` |

No callers of `formatWidgetOperationStatusText` or `buildWidgetWriteResult` need to change. The structural `appliedEdits` field is purely additive.

## Test plan

- [x] `node --check` on both modified files passes
- [x] `formatWidgetAppliedEditsFragment` sanity table verified for empty, undefined, single-edit, multi-edit, and mixed-kind cases
- [x] Patch validator and renderer-source threading remain functionally unchanged for atomic patch success and atomic failure paths; only the error messages and the result envelope are richer
- [x] Manual verification across two providers in `npm run desktop:pack` builds:
  - **gpt-5.4 via OpenAI Codex provider** — multi-edit patches now show the kind breakdown in the status; a deliberately broken `find` snippet returns an error that names the edit index, helping the agent fix only that entry on retry
  - **Local qwen3-coder model** — same behavior; the smaller model reads the structured fragment cleanly and uses the edit-index in its retry reasoning

## Relationship to other PRs

Compatible with PR #6 ("prevent agent widget editing loops"). The widget-skill rule *"If patchWidget() or renderWidget() says No files were written, the old widget file is still the source of truth. Fix and retry"* pattern-matches on the keyword phrase `was not found`. The new `Edit N (description):` prefix is *prepended* to the existing message, so every keyword phrase the skill rules match on (`was not found`, `is ambiguous`, `outside the readable renderer range`) is preserved verbatim. The agent additionally gets the index and short label of the failing edit so it can fix only that entry on retry instead of resubmitting the whole batch.

## Out of scope (possible follow-ups)

- Partial application (allow a multi-edit call to apply 4 of 5 edits and report the rejected one explicitly). This would change the atomic semantics of `patchWidget` and is a deliberate separate discussion.
- "Closest match candidates" on `find text not found`. The current PR includes the location count for ambiguous matches but does not yet suggest near-misses; a Levenshtein or token-based suggestion would be useful diagnostic but adds nontrivial code.
- Surfacing `appliedEdits` in the `Current Widget` transient envelope. The structured field on the tool result is the canonical surface; transient header is decorative.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
