### PR TITLE
fix(router): configurable upstream-fetch timeout for /api/proxy via PROXY_REQUEST_TIMEOUT_SECONDS

### DIFF
--- a/app/L0/_all/mod/_core/documentation/docs/cli/commands-and-runtime-params.md
+++ b/app/L0/_all/mod/_core/documentation/docs/cli/commands-and-runtime-params.md
@@ -189,6 +189,7 @@ Current params:
 - `GIT_BACKEND`
 - `GIT_URL`
 - `USER_FOLDER_SIZE_LIMIT_BYTES`
+- `PROXY_REQUEST_TIMEOUT_SECONDS`
 
 Important fields per param:
 
@@ -215,6 +216,7 @@ Only params with `frontend_exposed: true` are injected into page-shell meta tags
 - `GIT_BACKEND`: selects the backend used by server-owned Git flows such as local history and Git-backed module installs; defaults to `auto`, which keeps the normal `native -> isomorphic` fallback order, while concrete values force one backend for local testing or troubleshooting
 - `GIT_URL`: optional Git repository URL used by `node space update` and `node space supervise`; if unset they fall back to the local `origin` remote URL and only then to the canonical repo URL
 - `USER_FOLDER_SIZE_LIMIT_BYTES`: optional per-user `L2/<user>/` folder cap in bytes; `0` disables it, and positive values make app-file mutations reject projected growth over the cap while still allowing mutations that reduce an already-over-limit folder
+- `PROXY_REQUEST_TIMEOUT_SECONDS`: upstream-fetch timeout used by the `/api/proxy` handler in `server/router/proxy.js`; defaults to `900` (15 minutes) so long upstream prompt-prefill phases on local LLM servers are not cut off by the runtime fetch implementation's tight `headersTimeout`; `0` disables the proxy-imposed timeout entirely and leaves the call to lower-layer wall-clock limits; positive values apply as a wall-clock abort from the moment the proxy starts the upstream request
 - `user` and `group` commands flush pending local-history commits before returning when `CUSTOMWARE_GIT_HISTORY` is enabled because those commands are short-lived processes
 - `node space set CUSTOMWARE_PATH=<path>` should be run before creating users or groups when writable state should live outside the source checkout, because `user` and `group` commands resolve that stored parameter before deciding where `L1` and `L2` files belong
 - `node space supervise` requires `CUSTOMWARE_PATH` and uses it as the stable writable state boundary across source-release swaps

--- a/server/router/AGENTS.md
+++ b/server/router/AGENTS.md
@@ -103,6 +103,12 @@ Direct app-file fetches:
 - read permission checks are delegated to `createAppAccessController(...)`
 - `.git` metadata paths are blocked even when they live inside a readable writable-layer owner root
 
+Proxy:
+
+- `proxy.js` owns the outbound `/api/proxy` fetch transport plus header allow-listing for the upstream and response sides
+- the proxy applies a configurable wall-clock timeout to the upstream fetch via `PROXY_REQUEST_TIMEOUT_SECONDS` so long upstream prompt-prefill phases on local LLM servers are not cut off by the runtime fetch implementation's tight `headersTimeout` default; the param accepts `0` to disable the proxy-imposed timeout entirely, and timeout aborts surface to the client as `504 Gateway Timeout` with a hint to raise or disable the param
+- the proxy passes `runtimeParams` from the request context into `proxyExternalRequest(...)` so the timeout is resolved per-request and operators can change it at runtime via the params interface without restarting
+
 Responses:
 
 - `responses.js` owns JSON serialization, redirects, file responses, stream responses, and Web `Response` bridging

--- a/server/router/proxy.js
+++ b/server/router/proxy.js
@@ -42,6 +42,39 @@ const PROXY_RESPONSE_TARGET_HEADER = "x-space-proxy-target-url";
 const PROXY_RESPONSE_FINAL_HEADER = "x-space-proxy-final-url";
 const PROXY_RESPONSE_REDIRECTED_HEADER = "x-space-proxy-redirected";
 
+// Default upstream-fetch timeout for `/api/proxy` calls, in seconds. The
+// runtime fetch implementation (undici) imposes its own `headersTimeout` of
+// 300 seconds by default, which is too tight for upstream services that
+// stall before producing response headers — most importantly long
+// prompt-prefill phases on local LLM servers (llama.cpp, qwen serve, vLLM)
+// where the upstream stays silent for minutes during PP on long-context
+// conversations. Raise the default to 15 minutes so cold-cache replies are
+// not cut off by the proxy itself; operators can shorten it with
+// `PROXY_REQUEST_TIMEOUT_SECONDS=N` or disable the timeout entirely with
+// `PROXY_REQUEST_TIMEOUT_SECONDS=0`.
+const PROXY_REQUEST_TIMEOUT_PARAM_NAME = "PROXY_REQUEST_TIMEOUT_SECONDS";
+const PROXY_REQUEST_TIMEOUT_DEFAULT_SECONDS = 900;
+
+function resolveProxyRequestTimeoutMs(runtimeParams) {
+  if (!runtimeParams || typeof runtimeParams.get !== "function") {
+    return PROXY_REQUEST_TIMEOUT_DEFAULT_SECONDS * 1000;
+  }
+
+  const rawValue = runtimeParams.get(PROXY_REQUEST_TIMEOUT_PARAM_NAME);
+
+  if (rawValue === undefined || rawValue === null || rawValue === "") {
+    return PROXY_REQUEST_TIMEOUT_DEFAULT_SECONDS * 1000;
+  }
+
+  const numericValue = Number(rawValue);
+
+  if (!Number.isFinite(numericValue) || numericValue < 0) {
+    return PROXY_REQUEST_TIMEOUT_DEFAULT_SECONDS * 1000;
+  }
+
+  return Math.floor(numericValue * 1000);
+}
+
 function getTargetUrl(requestUrl, headers) {
   return requestUrl.searchParams.get("url") || headers[PROXY_TARGET_HEADER];
 }
@@ -115,7 +148,7 @@ async function pipeUpstreamBodyToResponse(res, upstreamResponse) {
   });
 }
 
-async function proxyExternalRequest(req, res, requestUrl) {
+async function proxyExternalRequest(req, res, requestUrl, options = {}) {
   const targetUrlValue = getTargetUrl(requestUrl, req.headers);
 
   if (!targetUrlValue) {
@@ -145,6 +178,18 @@ async function proxyExternalRequest(req, res, requestUrl) {
   const method = String(req.method || "GET").toUpperCase();
   const upstreamHeaders = createUpstreamHeaders(req.headers);
   const body = requestCanHaveBody(method) ? await readRequestBody(req) : undefined;
+
+  // Resolve the request-scoped abort signal. The optional caller-supplied
+  // timeout overrides undici's tight `headersTimeout` default so upstream
+  // services that stall before producing response headers (typically LLM
+  // servers during long prompt-prefill on warm-cache-miss requests) do not
+  // get cut off mid-PP. A configured timeout of 0 disables the timeout
+  // entirely; any other positive value applies as a wall-clock abort.
+  const timeoutMs = resolveProxyRequestTimeoutMs(options.runtimeParams);
+  const fetchSignal = timeoutMs > 0 && typeof AbortSignal?.timeout === "function"
+    ? AbortSignal.timeout(timeoutMs)
+    : undefined;
+
   let upstreamResponse;
 
   try {
@@ -152,9 +197,22 @@ async function proxyExternalRequest(req, res, requestUrl) {
       method,
       headers: upstreamHeaders,
       body,
-      redirect: "follow"
+      redirect: "follow",
+      signal: fetchSignal
     });
   } catch (error) {
+    const isTimeoutError = error?.name === "TimeoutError" || error?.code === "UND_ERR_HEADERS_TIMEOUT";
+
+    if (isTimeoutError) {
+      sendProxyError(
+        res,
+        504,
+        `Upstream did not respond within the configured proxy timeout of ${Math.round(timeoutMs / 1000)}s. ` +
+          `Increase ${PROXY_REQUEST_TIMEOUT_PARAM_NAME} (or set it to 0 to disable) for slower upstreams.`
+      );
+      return;
+    }
+
     sendProxyError(res, 502, `Upstream fetch failed: ${error.message}`);
     return;
   }
@@ -165,4 +223,9 @@ async function proxyExternalRequest(req, res, requestUrl) {
   await pipeUpstreamBodyToResponse(res, upstreamResponse);
 }
 
-export { proxyExternalRequest };
+export {
+  PROXY_REQUEST_TIMEOUT_DEFAULT_SECONDS,
+  PROXY_REQUEST_TIMEOUT_PARAM_NAME,
+  proxyExternalRequest,
+  resolveProxyRequestTimeoutMs
+};

--- a/server/router/router.js
+++ b/server/router/router.js
@@ -348,7 +348,7 @@ function createRequestHandler(options) {
           return;
         }
 
-        await proxyExternalRequest(req, res, requestUrl);
+        await proxyExternalRequest(req, res, requestUrl, { runtimeParams });
         return;
       }
 

--- a/tests/proxy_request_timeout_test.mjs
+++ b/tests/proxy_request_timeout_test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  PROXY_REQUEST_TIMEOUT_DEFAULT_SECONDS,
+  PROXY_REQUEST_TIMEOUT_PARAM_NAME,
+  resolveProxyRequestTimeoutMs
+} from "../server/router/proxy.js";
+
+function createStaticRuntimeParams(values = {}) {
+  return {
+    get(name) {
+      return Object.prototype.hasOwnProperty.call(values, name) ? values[name] : undefined;
+    }
+  };
+}
+
+test("resolveProxyRequestTimeoutMs falls back to the default when no runtime params are provided", () => {
+  const expectedMs = PROXY_REQUEST_TIMEOUT_DEFAULT_SECONDS * 1000;
+
+  assert.equal(resolveProxyRequestTimeoutMs(undefined), expectedMs);
+  assert.equal(resolveProxyRequestTimeoutMs(null), expectedMs);
+  assert.equal(resolveProxyRequestTimeoutMs({}), expectedMs);
+});
+
+test("resolveProxyRequestTimeoutMs falls back to the default when the param is unset, empty, or non-numeric", () => {
+  const expectedMs = PROXY_REQUEST_TIMEOUT_DEFAULT_SECONDS * 1000;
+
+  assert.equal(resolveProxyRequestTimeoutMs(createStaticRuntimeParams()), expectedMs);
+  assert.equal(
+    resolveProxyRequestTimeoutMs(createStaticRuntimeParams({ [PROXY_REQUEST_TIMEOUT_PARAM_NAME]: "" })),
+    expectedMs
+  );
+  assert.equal(
+    resolveProxyRequestTimeoutMs(createStaticRuntimeParams({ [PROXY_REQUEST_TIMEOUT_PARAM_NAME]: "abc" })),
+    expectedMs
+  );
+  assert.equal(
+    resolveProxyRequestTimeoutMs(createStaticRuntimeParams({ [PROXY_REQUEST_TIMEOUT_PARAM_NAME]: -10 })),
+    expectedMs
+  );
+});
+
+test("resolveProxyRequestTimeoutMs honors a positive override value in seconds", () => {
+  assert.equal(
+    resolveProxyRequestTimeoutMs(createStaticRuntimeParams({ [PROXY_REQUEST_TIMEOUT_PARAM_NAME]: 1200 })),
+    1_200_000
+  );
+  assert.equal(
+    resolveProxyRequestTimeoutMs(createStaticRuntimeParams({ [PROXY_REQUEST_TIMEOUT_PARAM_NAME]: "60" })),
+    60_000
+  );
+});
+
+test("resolveProxyRequestTimeoutMs maps 0 to a disabled timeout so operators can turn the guard off", () => {
+  // A configured `PROXY_REQUEST_TIMEOUT_SECONDS=0` means the proxy should
+  // make no timeout decision of its own and rely on lower layers (kernel,
+  // upstream server, manual cancel). The caller checks for `timeoutMs > 0`
+  // before constructing an `AbortSignal.timeout(...)`.
+  assert.equal(
+    resolveProxyRequestTimeoutMs(createStaticRuntimeParams({ [PROXY_REQUEST_TIMEOUT_PARAM_NAME]: 0 })),
+    0
+  );
+  assert.equal(
+    resolveProxyRequestTimeoutMs(createStaticRuntimeParams({ [PROXY_REQUEST_TIMEOUT_PARAM_NAME]: "0" })),
+    0
+  );
+});
+
+test("resolveProxyRequestTimeoutMs truncates fractional seconds down to whole milliseconds", () => {
+  assert.equal(
+    resolveProxyRequestTimeoutMs(createStaticRuntimeParams({ [PROXY_REQUEST_TIMEOUT_PARAM_NAME]: 1.5 })),
+    1500
+  );
+});
+
+test("PROXY_REQUEST_TIMEOUT_DEFAULT_SECONDS is at least one minute past the undici headers-timeout default", () => {
+  // undici's built-in `headersTimeout` default is 300 seconds. The proxy
+  // override must stay comfortably above that, otherwise long upstream
+  // prompt-prefill phases still get cut by the inner client default before
+  // our explicit timeout takes effect.
+  assert.ok(PROXY_REQUEST_TIMEOUT_DEFAULT_SECONDS >= 360);
+});


### PR DESCRIPTION
## Summary

The `/api/proxy` handler in `server/router/proxy.js` calls `fetch(targetUrl, { method, headers, body, redirect: "follow" })` without an explicit `signal`. Node.js's runtime fetch (undici) then applies its built-in `headersTimeout: 300_000` ms (5 minutes), which is too tight for upstream services that stall before producing response headers.

Concretely: on cold-cache LLM requests against local servers (llama.cpp `--prompt-cache`, qwen serve, vLLM, etc.) the upstream stays silent for the duration of prompt-prefill, which can be several minutes for ~100k+ token prompts. Undici aborts the fetch at 5 minutes, the proxy returns 502 to the client, and the in-app fetch proxy surfaces a connection error to the user — even though both ends were still healthy and the model would have started streaming a few seconds later.

## Fix

- New runtime param `PROXY_REQUEST_TIMEOUT_SECONDS` (default `900` = 15 minutes).
- `0` disables the proxy-imposed timeout entirely and leaves the call to lower-layer wall-clock limits.
- Positive values apply as a wall-clock `AbortSignal.timeout(...)` on the upstream `fetch(...)`.
- Timeout aborts surface to the client as `504 Gateway Timeout` with a hint that operators can raise or disable the param. Non-timeout upstream failures keep the existing `502` shape so they remain distinguishable.

The plumbing is small: `router.js` already has `runtimeParams` in scope for the request context and now forwards it as an options argument to `proxyExternalRequest(...)`. The handler resolves the configured timeout per request, so an operator can change the param at runtime via the params interface without restarting.

## Scope

- `server/router/proxy.js`: param resolution helper, signal attachment, new timeout-aware 504 path
- `server/router/router.js`: pass `runtimeParams` through to the proxy handler at the single existing call site
- `app/L0/_all/mod/_core/documentation/docs/cli/commands-and-runtime-params.md`: add `PROXY_REQUEST_TIMEOUT_SECONDS` to the runtime-params schema list and the high-value-params descriptions
- `server/router/AGENTS.md`: new Proxy contract block describing the timeout flow, the `504` aborted-call response, and the per-request resolution path through `runtimeParams`
- `tests/proxy_request_timeout_test.mjs`: 6 focused unit tests covering default fallback, positive override, the `0` disable signal, fractional-second truncation, and a regression guard that the default stays comfortably above undici's built-in 300-second `headersTimeout`

No protocol changes, no API changes, no behavior change for callers that do not exceed the default timeout. Existing call sites of `proxyExternalRequest(...)` (there is exactly one) get the new options argument with the in-scope `runtimeParams`.

## Why a runtime param rather than a constant

Local development with small models has very different upstream-latency characteristics from production deployments against high-throughput hosted endpoints. The same proxy serves both, so the upstream-tolerance budget belongs in operator-controlled config rather than a hardcoded constant.

The default of 900 seconds (15 minutes) covers realistic cold-prefill phases on 100k+ token prompts running on local consumer hardware while still acting as a safety net against truly stuck upstreams.

## Test plan

- [x] `node --test tests/proxy_request_timeout_test.mjs` — 6/6 pass.
- [ ] In-app verification under a llama.cpp prefix-cache backend with a cold-cache `/api/proxy` request: the proxy does not return 502 inside 5 minutes; the upstream eventually produces response headers and the proxy pipes them through normally.

## Related

- PR #69 (long-message placeholder counter byte-stability) and PR #70 (long-message cut-position quantum) reduce how often a cold prompt-prefill is needed in the first place, by keeping the prompt prefix byte-stable across turns so warm-cache reuse works on long-context conversations. This PR removes the remaining hard ceiling that the proxy itself imposed on the rare cold-cache case that still occurs.

Credit for the diagnosis goes to the archllm operator on the long-context inference rig, who traced the 5-minute cutoff from server-side `BrokenPipeError` logs and ruled out the Talk client as the source.