### PR TITLE
feat: add Nix flake and Devbox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,49 @@ Grab the latest build from [GitHub Releases](https://github.com/agent0ai/space-a
 
 <a id="host"></a>
 
+#### With Nix (flakes)
+
+```bash
+nix run github:agent0ai/space-agent
+```
+
+Or install permanently:
+
+```bash
+nix profile install github:agent0ai/space-agent
+```
+
+#### With Devbox
+
+```bash
+# Install devbox first (if not already installed)
+curl -fsSL https://get.jetify.dev/devbox | bash
+
+# Clone the repository
+git clone https://github.com/agent0ai/space-agent.git
+cd space-agent
+
+# Initialize the environment
+devbox shell
+
+# Install dependencies
+devbox run install
+
+# create yourself an admin
+node space user create admin --password "change-me-now" --full-name "Admin" --groups _admin
+
+# start the server
+node space serve
+```
+
+Or install devbox via Homebrew:
+
+```bash
+brew install jetify-com/devbox/devbox
+```
+
+#### From source
+
 ```bash
 git clone https://github.com/agent0ai/space-agent.git
 cd space-agent

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.12.0/.schema/devbox.schema.json",
+  "packages": [
+    "nodejs_22"
+  ],
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to the space-agent devbox environment!'"
+    ],
+    "scripts": {
+      "install": "npm install",
+      "start": "node space serve",
+      "dev": "node server/dev_server.js"
+    }
+  }
+}

--- a/devbox.json
+++ b/devbox.json
@@ -1,16 +1,19 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.12.0/.schema/devbox.schema.json",
-  "packages": [
-    "nodejs_22"
-  ],
+  "packages": {
+    "nodejs_22": ""
+  },
+  "nixpkgs": {
+    "commit": "8623c4c20aa4ca2f5fb81510d2944066c3fb0d96"
+  },
   "shell": {
     "init_hook": [
       "echo 'Welcome to the space-agent devbox environment!'"
     ],
     "scripts": {
       "install": "npm install",
-      "start": "node space serve",
-      "dev": "node server/dev_server.js"
+      "start":   "node space serve",
+      "dev":     "node server/dev_server.js"
     }
   }
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,58 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "github:NixOS/nixpkgs/8623c4c20aa4ca2f5fb81510d2944066c3fb0d96": {
+      "last_modified": "1970-01-01T00:00:00Z",
+      "resolved": "github:NixOS/nixpkgs/8623c4c20aa4ca2f5fb81510d2944066c3fb0d96"
+    },
+    "nodejs_22@latest": {
+      "last_modified": "2026-06-27T07:37:20Z",
+      "plugin_version": "0.0.4",
+      "resolved": "github:NixOS/nixpkgs/3d46470bb3030020f7e1361f33514854f5bfa86d#nodejs_22",
+      "source": "devbox-search",
+      "version": "22.23.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3vg1dzhdv5pqsykpbm8cxy7v276p1wgg-nodejs-22.23.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3vg1dzhdv5pqsykpbm8cxy7v276p1wgg-nodejs-22.23.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/jkqp8rd333469zmh65pyf76n68v9kzdm-nodejs-22.23.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/jkqp8rd333469zmh65pyf76n68v9kzdm-nodejs-22.23.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/l1yfdvdrz1vl6f3wsyjglxgsk6r29rkn-nodejs-22.23.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/l1yfdvdrz1vl6f3wsyjglxgsk6r29rkn-nodejs-22.23.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/l7b3cb5p19qnlykasxwqdggck3ijilqq-nodejs-22.23.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/l7b3cb5p19qnlykasxwqdggck3ijilqq-nodejs-22.23.1"
+        }
+      }
+    }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  description = "Browser-first AI agent with a thin Node.js server";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        space-agent = pkgs.buildNpmPackage {
+          pname = "space-agent";
+          version = "0.36.0";
+          src = ./.;
+
+          npmDeps = pkgs.fetchNpmDeps {
+            src = ./.;
+            hash = "sha256-GvKSULl2i+6pDjrodxFKgeA0FS/jeGnHS+sas8GVj38=";
+          };
+
+          dontNpmBuild = true;
+
+          installPhase = ''
+            mkdir -p $out/bin
+            mkdir -p $out/lib/node_modules/space-agent
+
+            # Copy all source files
+            cp -r . $out/lib/node_modules/space-agent/
+
+            # Create wrapper script
+            cat > $out/bin/space <<EOF
+    #!${pkgs.bash}/bin/bash
+    cd $out/lib/node_modules/space-agent
+    exec ${pkgs.nodejs_22}/bin/node space "\$@"
+    EOF
+
+            chmod +x $out/bin/space
+          '';
+
+          meta = {
+            description = "Browser-first AI agent with a thin Node.js server";
+            homepage = "https://github.com/agent0ai/space-agent";
+            license = pkgs.lib.licenses.mit;
+            mainProgram = "space";
+          };
+        };
+      in
+      {
+        packages.default = space-agent;
+        apps.default = {
+          type = "app";
+          program = "${space-agent}/bin/space";
+        };
+
+        overlays.default = final: prev: {
+          space-agent = space-agent;
+        };
+
+        checks = {
+          build = space-agent;
+        };
+      }
+    );
+}


### PR DESCRIPTION
Adds a Nix flake so the project can be installed and run directly from GitHub without manual compilation:

    nix run github:agent0ai/space-agent
    nix profile install github:agent0ai/space-agent

Adds devbox.json for reproducible development environments:

    devbox shell
    devbox run install

Also updates README install instructions to include Nix and Devbox.

- Uses Node.js 22 (Node.js 20 is marked as insecure)
- Builds from source using buildNpmPackage
- Includes npmDeps hash for reproducible builds

Closes #75 